### PR TITLE
Fix error "dh key too small" with OpenSSL 1.1.1

### DIFF
--- a/roomba/mqttclient.py
+++ b/roomba/mqttclient.py
@@ -80,12 +80,14 @@ class RoombaMQTTClient:
             mqtt_client.tls_set(
                 ca_certs=self.cert_path,
                 cert_reqs=ssl.CERT_NONE,
-                tls_version=ssl.PROTOCOL_TLS)
+                tls_version=ssl.PROTOCOL_TLS,
+                ciphers='DEFAULT@SECLEVEL=1')
         except ValueError:  # try V1.3 version
             self.log.warning("TLS Setting failed - trying 1.3 version")
             mqtt_client._ssl_context = None
             ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
             ssl_context.verify_mode = ssl.CERT_NONE
+            ssl_context.set_ciphers('DEFAULT@SECLEVEL=1')
             ssl_context.load_default_certs()
             mqtt_client.tls_set_context(ssl_context)
         mqtt_client.tls_insecure_set(True)


### PR DESCRIPTION
@NickWaterton added it to his code
With the introduction of openssl version 1.1.1 in Debian several packages have become buggy. This is due to changes in openssl that may come up during run time. 
This is caused by the SECLEVEL 2 setting the security level to 112 bit. This means that RSA and DHE keys need to be at least 2048 bit long. SHA-1 is no longer supported for signatures in certificates and you need at least SHA-256. Note that CAs have stopped issuing certificates that didn't meet those requirements in January 2015, and since January 2017 all valid CA certificates should meet those requirements. However there are certificates generated by private CAs or that are in a test suite that do not meet those requirements.