### PR TITLE
Add multi-type support to set_preference

### DIFF
--- a/roomba/roomba.py
+++ b/roomba/roomba.py
@@ -309,9 +309,13 @@ class Roomba:
 
     def set_preference(self, preference, setting):
         self.log.debug("Set preference: %s, %s", preference, setting)
-        val = False
-        if setting.lower() == "true":
-            val = True
+        val = setting
+        # Parse boolean string
+        if isinstance(setting, str):
+            if setting.lower() == "true":
+                val = True
+            elif setting.lower() == "false":
+                val = False
         tmp = {preference: val}
         roomba_command = {"state": tmp}
         str_command = json.dumps(roomba_command)


### PR DESCRIPTION
I'm working on [PR 33616](https://github.com/home-assistant/core/pull/33616) of home assistant. Currently the `set_preference` function only support boolean strings as the value of setting. This PR fixes the problem so that `setting` can be other types like integers or dictionaries so that I can hide protocol details from Home Assistant.