### PR TITLE
Fix error message

### DIFF
--- a/roomba/roomba.py
+++ b/roomba/roomba.py
@@ -435,11 +435,11 @@ class Roomba:
                     self.bin_full = v
                 if k == "cleanMissionStatus_error":
                     try:
-                        error_message = self._ErrorMessages[v]
+                        self.error_message = self._ErrorMessages[v]
                     except KeyError as e:
                         self.log.warning("Error looking up Roomba error " "message: %s", e)
-                        error_message = "Unknown Error number: %d" % v
-                    self.publish("error_message", error_message)
+                        self.error_message = "Unknown Error number: %d" % v
+                    self.publish("error_message", self.error_message)
                 if k == "cleanMissionStatus_phase":
                     self.previous_cleanMissionStatus_phase = (
                         self.cleanMissionStatus_phase


### PR DESCRIPTION
According to [#35055](https://github.com/home-assistant/core/issues/35055), home assistant cannot get error messages. It appears that the home assistant integration already have [something implemented](https://github.com/home-assistant/core/blob/d9b9a004d221a5de86d4b96da5e98541d054e6a1/homeassistant/components/roomba/irobot_base.py#L173) but it expects the `Roomba` object to have an `error_message` attribute. This is a quick fix.