### PR TITLE
Fix send_command

### DIFF
--- a/roomba/roomba.py
+++ b/roomba/roomba.py
@@ -318,7 +318,7 @@ class Roomba:
         self.log.debug("Send command: %s", command)
         roomba_command = {
             "command": command,
-            "time": datetime.timestamp(datetime.now()),
+            "time": int(datetime.timestamp(datetime.now())),
             "initiator": "localApp"
         }
         roomba_command.update(params)


### PR DESCRIPTION
`datetime.timestamp` returns the timestamp in float while the robot seems to expect a integer value. My Braava jet refused to response to any commands when a float timestamp is given.