### PR TITLE
Fix cipher

### DIFF
--- a/roomba/mqttclient.py
+++ b/roomba/mqttclient.py
@@ -75,13 +75,13 @@ class RoombaMQTTClient:
             mqtt_client.tls_set(
                 cert_reqs=ssl.CERT_NONE,
                 tls_version=ssl.PROTOCOL_TLS,
-                ciphers='DEFAULT@SECLEVEL=1')
+                ciphers='DEFAULT:!DH')
         except ValueError:  # try V1.3 version
             self.log.warning("TLS Setting failed - trying 1.3 version")
             mqtt_client._ssl_context = None
             ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
             ssl_context.verify_mode = ssl.CERT_NONE
-            ssl_context.set_ciphers('DEFAULT@SECLEVEL=1')
+            ssl_context.set_ciphers('DEFAULT:!DH')
             ssl_context.load_default_certs()
             mqtt_client.tls_set_context(ssl_context)
         mqtt_client.tls_insecure_set(True)

--- a/roomba/mqttclient.py
+++ b/roomba/mqttclient.py
@@ -74,12 +74,14 @@ class RoombaMQTTClient:
         try:
             mqtt_client.tls_set(
                 cert_reqs=ssl.CERT_NONE,
-                tls_version=ssl.PROTOCOL_TLS)
+                tls_version=ssl.PROTOCOL_TLS,
+                ciphers='DEFAULT@SECLEVEL=1')
         except ValueError:  # try V1.3 version
             self.log.warning("TLS Setting failed - trying 1.3 version")
             mqtt_client._ssl_context = None
             ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
             ssl_context.verify_mode = ssl.CERT_NONE
+            ssl_context.set_ciphers('DEFAULT@SECLEVEL=1')
             ssl_context.load_default_certs()
             mqtt_client.tls_set_context(ssl_context)
         mqtt_client.tls_insecure_set(True)


### PR DESCRIPTION
The `ciphers='DEFAULT@SECLEVEL=1'` was removed in #36. I think it causes home-assistant/core#35407. So I add it back. It should fix the problem.