### PR TITLE
Exclude tests from installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'Topic :: System :: Networking'
     ],
     keywords='roomba irobot braava home-assistant',
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests', 'tests.*')),
     install_requires=['paho-mqtt'],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Should not be desirable in the first place, and especially not in a global top level `tests` package. `tests.*` is there in case some subpackages will be introduced there in the future.