### PR TITLE
Correct `on_disconnect` signature

### DIFF
--- a/roomba/mqttclient.py
+++ b/roomba/mqttclient.py
@@ -86,7 +86,7 @@ class RoombaMQTTClient:
         if self.on_connect is not None:
             self.on_connect(connection_error)
 
-    def _internal_on_disconnect(self, client, userdata, flags, rc):
+    def _internal_on_disconnect(self, client, userdata, rc):
         self.log.debug("Disconnected from Roomba %s, response code = %s", self.address, rc)
         connection_error = MQTT_ERROR_MESSAGES[rc]
         if self.on_disconnect is not None:


### PR DESCRIPTION
Correct `on_disconnect` signature, there is no `flags` parameter

Reported in https://github.com/home-assistant/core/issues/43388