### PR TITLE
Adding missing evac const for Roomba i7+ bin

### DIFF
--- a/roomba/const.py
+++ b/roomba/const.py
@@ -105,5 +105,6 @@ ROOMBA_STATES = {
     "stop": "Stopped",
     "pause": "Paused",
     "hmPostMsn": "End Mission",
+    "evac": "Emptying Bin",
     "": None,
 }


### PR DESCRIPTION
The Roomba i7+ consists of a Roomba i7 plus a bin, allowing the robot to self-empty itself if the built-in bin is full. 

The roombapy currently misses a constant in const.py and this causes an exception when this action is performed. 

This PR fixes #50 

(This is my first PR, I hope it's done properly)