### PR TITLE
Include name for the thread

### DIFF
--- a/roombapy/roomba.py
+++ b/roombapy/roomba.py
@@ -80,7 +80,7 @@ class Roomba:
         self.master_state = {}  # all info from roomba stored here
         self.time = time.time()
         self.update_seconds = 300  # update with all values every 5 minutes
-        self._thread = threading.Thread(target=self.periodic_connection)
+        self._thread = threading.Thread(target=self.periodic_connection, name="roombapy")
         self.on_message_callbacks = []
         self.on_disconnect_callbacks = []
         self.error_code = None

--- a/roombapy/roomba.py
+++ b/roombapy/roomba.py
@@ -80,7 +80,9 @@ class Roomba:
         self.master_state = {}  # all info from roomba stored here
         self.time = time.time()
         self.update_seconds = 300  # update with all values every 5 minutes
-        self._thread = threading.Thread(target=self.periodic_connection, name="roombapy")
+        self._thread = threading.Thread(
+            target=self.periodic_connection, name="roombapy"
+        )
         self.on_message_callbacks = []
         self.on_disconnect_callbacks = []
         self.error_code = None


### PR DESCRIPTION
I have been working on reducing the number of threads running in
Home Assistant, as such naming them is helpful to prioritizing what
needs to be converted to asyncio