### PR TITLE
Fix connecting to older roombas with openssl3

### DIFF
--- a/roombapy/remote_client.py
+++ b/roombapy/remote_client.py
@@ -19,6 +19,8 @@ def _generate_tls_context() -> ssl.SSLContext:
     ssl_context.verify_mode = ssl.CERT_NONE
     ssl_context.set_ciphers("DEFAULT:!DH")
     ssl_context.load_default_certs()
+    # ssl.OP_LEGACY_SERVER_CONNECT is only available in Python 3.12a4+
+    ssl_context.options |= getattr(ssl, "OP_LEGACY_SERVER_CONNECT", 0x4)
     return ssl_context
 
 


### PR DESCRIPTION
HA 2023.5 images use alpine 3.17 which uses openssl3 which flips this flag off by default so we need to flip it back to work with older roombas

This is same fix as https://github.com/gwww/elkm1/pull/69 but for roombas