### PR TITLE
Make roomaby usable for smarthomeNG

### DIFF
--- a/roombapy/roomba.py
+++ b/roombapy/roomba.py
@@ -113,6 +113,7 @@ class Roomba:
         self.time = time.time()  # save connection time
 
     def _connect(self):
+        self.client_error=None
         is_connected = self.remote_client.connect()
         if not is_connected:
             raise RoombaConnectionError(


### PR DESCRIPTION
cache is only available from Python 3.9 - lru_cache can be used instead
importing pointed to "." instead of "roombapy"
MQTT client does not fire on_connect if connection is refused by Roomba. Passing the error message back to roomby.py