### PR TITLE
Extended error reporting on connect

### DIFF
--- a/roombapy/discovery.py
+++ b/roombapy/discovery.py
@@ -3,7 +3,7 @@ import socket
 
 import orjson
 
-from roombapy.roomba_info import RoombaInfo
+from .roomba_info import RoombaInfo
 
 
 class RoombaDiscovery:

--- a/roombapy/entry_points.py
+++ b/roombapy/entry_points.py
@@ -1,8 +1,8 @@
 import sys
 
-from roombapy import RoombaFactory
-from roombapy.discovery import RoombaDiscovery
-from roombapy.getpassword import RoombaPassword
+from . import RoombaFactory
+from .discovery import RoombaDiscovery
+from .getpassword import RoombaPassword
 
 
 def discovery():

--- a/roombapy/remote_client.py
+++ b/roombapy/remote_client.py
@@ -71,12 +71,15 @@ class RoombaRemoteClient:
                 self._open_mqtt_connection()
                 return True
             except Exception as e:
+                _last_error = "Can't connect to {}, error: {}".format(self.address, e)
                 self.log.error(
                     "Can't connect to %s, error: %s", self.address, e
                 )
             attempt += 1
 
         self.log.error("Unable to connect to %s", self.address)
+        if self.on_connect is not None:
+            self.on_connect(_last_error)
         return False
 
     def disconnect(self):

--- a/roombapy/remote_client.py
+++ b/roombapy/remote_client.py
@@ -1,6 +1,6 @@
 import logging
 import ssl
-from functools import cache
+from functools import lru_cache
 
 import paho.mqtt.client as mqtt
 
@@ -9,7 +9,7 @@ from .const import MQTT_ERROR_MESSAGES
 MAX_CONNECTION_RETRIES = 3
 
 
-@cache
+@lru_cache(maxsize=None)
 def _generate_tls_context() -> ssl.SSLContext:
     """Generate TLS context.
 

--- a/roombapy/remote_client.py
+++ b/roombapy/remote_client.py
@@ -4,7 +4,7 @@ from functools import cache
 
 import paho.mqtt.client as mqtt
 
-from roombapy.const import MQTT_ERROR_MESSAGES
+from .const import MQTT_ERROR_MESSAGES
 
 MAX_CONNECTION_RETRIES = 3
 

--- a/roombapy/roomba.py
+++ b/roombapy/roomba.py
@@ -24,7 +24,7 @@ from datetime import datetime
 
 import orjson
 
-from roombapy.const import ROOMBA_ERROR_MESSAGES, ROOMBA_STATES
+from .const import ROOMBA_ERROR_MESSAGES, ROOMBA_STATES
 
 MAX_CONNECTION_RETRIES = 3
 

--- a/roombapy/roomba.py
+++ b/roombapy/roomba.py
@@ -113,6 +113,7 @@ class Roomba:
         self.time = time.time()  # save connection time
 
     def _connect(self):
+        self.client_error=None
         is_connected = self.remote_client.connect()
         if not is_connected:
             raise RoombaConnectionError(

--- a/roombapy/roomba_factory.py
+++ b/roombapy/roomba_factory.py
@@ -1,5 +1,5 @@
-from roombapy import Roomba
-from roombapy.remote_client import RoombaRemoteClient
+from . import Roomba
+from .remote_client import RoombaRemoteClient
 
 
 class RoombaFactory:


### PR DESCRIPTION
_open_mqtt_connection does not fire on_connect if Roomba refuses connection, so that client_error will stay empty in that case.
Extended the connect method to add this scenario.