### PR TITLE
Fix SLF001

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ ignore = [
     "PLW2901",
     "RET507",
     "SIM102",
-    "SLF001",
 ]
 select = ["ALL"]
 

--- a/roombapy/remote_client.py
+++ b/roombapy/remote_client.py
@@ -107,7 +107,6 @@ class RoombaRemoteClient:
         mqtt_client.on_disconnect = self._internal_on_disconnect
 
         self.log.debug("Setting TLS certificate")
-        mqtt_client._ssl_context = None
         ssl_context = generate_tls_context()
         mqtt_client.tls_set_context(ssl_context)
         mqtt_client.tls_insecure_set(True)


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/no-slots-in-tuple-subclass/

Looking at the pago-mqtt code this might be a safe fix since the ssl context is never set.