### PR TITLE
ignore BLE001

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ ignore = [
     "ANN205",
     "ANN201", # Return type
     "ANN401", # Opinioated warning on disallowing dynamically typed expressions
-    "BLE001",
     "B007",
     "C901",
     "D105",

--- a/roombapy/remote_client.py
+++ b/roombapy/remote_client.py
@@ -70,7 +70,7 @@ class RoombaRemoteClient:
             try:
                 self._open_mqtt_connection()
                 return True
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 self.log.error(
                     "Can't connect to %s, error: %s", self.address, e
                 )


### PR DESCRIPTION
ignore BLE001 since this function can actually raise an `Exception` so this lint exception is in order