### PR TITLE
Simplify decoding

### DIFF
--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1,0 +1,37 @@
+"""Test the decoding of the Roomba messages."""
+from roombapy.roomba import _decode_payload
+
+
+def test_skip_garbage() -> None:
+    """Skip garbage data in payload."""
+    assert _decode_payload(b"\x00") is None
+
+
+def test_skip_broken_json() -> None:
+    """Skip broken JSON."""
+    assert _decode_payload(b"[") is None
+    assert _decode_payload(b"{") is None
+
+
+def test_skip_non_object_json() -> None:
+    """Allow only objects in messages."""
+    assert _decode_payload(b"[]") is None
+    assert _decode_payload(b"12") is None
+
+
+def test_allow_empty_json() -> None:
+    """Allow empty objects."""
+    assert _decode_payload(b"{}") == {}
+
+
+def test_allow_valid_json() -> None:
+    """Properly decode valid JSON object."""
+    payload = b"""
+    {"state": {"reported": {"signal": {"rssi": -45, "snr": 18, "noise": -63}}}}
+    """
+    decoded = {
+        "state": {
+            "reported": {"signal": {"rssi": -45, "snr": 18, "noise": -63}}
+        }
+    }
+    assert _decode_payload(payload) == decoded


### PR DESCRIPTION
`decode_payload` was, in fact, useless. There is no _correct_ way to deal with invalid messages except of omitting them.

Also, JSON doesn't support NaNs and ±inf, so trying to sneak them to orjson (which, in turn «has strict JSON conformance in not supporting Nan/Infinity/-Infinity») makes no sense.