### PR TITLE
Use the same type for capabilities as in reverse-engineered *.class

### DIFF
--- a/roombapy/roomba_info.py
+++ b/roombapy/roomba_info.py
@@ -8,7 +8,7 @@ from functools import cached_property
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-Capabilities = dict[str, int] | None
+Capabilities = dict[str, int | None] | None
 
 
 @dataclass


### PR DESCRIPTION
See #281