### PR TITLE
Update to paho-mqtt 2.1.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -321,12 +321,12 @@ files = [
 
 [[package]]
 name = "paho-mqtt"
-version = "1.6.1"
+version = "2.1.0"
 description = "MQTT version 5.0/3.1.1 client class"
 optional = false
 python-versions = "*"
 files = [
-    {file = "paho-mqtt-1.6.1.tar.gz", hash = "sha256:2a8291c81623aec00372b5a85558a372c747cbca8e9934dfe218638b8eefc26f"},
+    {file = "paho-mqtt-2.1.0.tar.gz", hash = "sha256:12d6e7511d4137555a3f6ea167ae846af2c7357b10bc6fa4f7c3968fc1723834"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ roombapy = "roombapy.cli:cli"
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
 orjson = ">=3.9.13"
-paho-mqtt = "~1.6.1"
+paho-mqtt = "~2.1.0"
 mashumaro = {version = "^3.12"}
 click = { version = "^8.1", optional = true }
 tabulate = { version = "^0.9", optional = true }

--- a/roombapy/remote_client.py
+++ b/roombapy/remote_client.py
@@ -122,7 +122,10 @@ class RoombaRemoteClient:
         self.mqtt_client.loop_start()
 
     def _get_mqtt_client(self) -> mqtt.Client:
-        mqtt_client = mqtt.Client(client_id=self.blid)
+        mqtt_client = mqtt.Client(
+            callback_api_version=mqtt.CallbackAPIVersion.VERSION1,
+            client_id=self.blid
+            )
         mqtt_client.username_pw_set(username=self.blid, password=self.password)
         mqtt_client.on_connect = self._internal_on_connect
         mqtt_client.on_disconnect = self._internal_on_disconnect


### PR DESCRIPTION
Hi,

i wanna help get this PR in home-assistant get done.
https://github.com/home-assistant/core/pull/136130

As far as i understand the paho-mqtt documentation, bumping the version and adding CallbackAPIVersion.Version1, when creating the Client object should be enough.
https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html

You might want to remove types-paho-mqtt, because it isnt needed anymore.
https://pypi.org/project/types-paho-mqtt/1.6.0.20240321/

I cant test this, because i dont own a roomba.

Thank you.