### PR TITLE
Add error msg for 16

### DIFF
--- a/roombapy/const.py
+++ b/roombapy/const.py
@@ -15,6 +15,7 @@ MQTT_ERROR_MESSAGES: dict[TransportErrorCode, TransportErrorMessage] = {
     4: "Bad username or password",
     5: "Not authorised",
     7: "The connection was lost",
+    16: "Client or broker did not communicate in the keepalive interval",
 }
 
 # iRobot_6.3.1-release.apk / res/values-en-rGB/strings.xml


### PR DESCRIPTION
https://github.com/pschmitt/roombapy/issues/355

I think this is actually the `ROOMBA_ERROR_MESSAGES[16]`, which over time results in a disconnect after the battery drains. Not exactly sure about this solution, but it should at least prevent the error logs. Some more info [here.](https://homesupport.irobot.com/s/article/21035#:~:text=Error%20sixteen%20(16)%20means%20your,when%20pressing%20the%20CLEAN%20button.)