### PR TITLE
feat: introduce an adhoc connection mode

### DIFF
--- a/roombapy/const.py
+++ b/roombapy/const.py
@@ -162,3 +162,7 @@ ROOMBA_STATES: dict[str, State] = {
     "completed": "Mission Complete",
     "": None,
 }
+
+_SENTINEL_UNSET = object()
+
+CONNECTION_MODES = ["continuous", "periodic", "adhoc"]

--- a/tests/test_roomba_factory.py
+++ b/tests/test_roomba_factory.py
@@ -1,0 +1,72 @@
+"""Test the RoombaFactory class."""
+
+import pytest
+from roombapy import RoombaFactory
+
+
+def test_roomba_factory() -> None:
+    """Test RoombaFactory with dummy params."""
+    roomba = RoombaFactory.create_roomba(
+        address="dummy",
+        blid="dummy",
+        password="dummy",
+    )
+
+    assert roomba.conn_mode == "continuous"
+    assert roomba.delay == 1
+
+
+def test_roomba_factory_compatibility() -> None:
+    """Test RoombaFactory compatibility mapping."""
+    roomba = RoombaFactory.create_roomba(
+        address="dummy",
+        blid="dummy",
+        password="dummy",
+        continuous=False,
+        delay=60,
+    )
+
+    assert roomba.conn_mode == "periodic"
+    assert roomba.delay == 60
+
+
+def test_roomba_factory_adhoc() -> None:
+    """Test RoombaFactory with adhoc connection mode."""
+    roomba = RoombaFactory.create_roomba(
+        address="dummy",
+        blid="dummy",
+        password="dummy",
+        mode="adhoc",
+    )
+
+    assert roomba.conn_mode == "adhoc"
+    assert roomba.delay == 1
+
+
+def test_roomba_factory_throws_exclusive() -> None:
+    """Test RoombaFactory with mutualy exclusive parameters."""
+    with pytest.raises(
+        ValueError,
+        match="The continuous and mode parameters are mutually exclusive!",
+    ):
+        _roomba = RoombaFactory.create_roomba(
+            address="dummy",
+            blid="dummy",
+            password="dummy",
+            mode="adhoc",
+            continuous=True,
+        )
+
+
+def test_roomba_factory_throws_invalid_mode() -> None:
+    """Test RoombaFactory with invalid connection mode."""
+    with pytest.raises(
+        ValueError,
+        match="The mode parameter does not contain a recognized value!",
+    ):
+        _roomba = RoombaFactory.create_roomba(
+            address="dummy",
+            blid="dummy",
+            password="dummy",
+            mode="temporary",
+        )


### PR DESCRIPTION
The intent of this PR is to make a proposal to rethink the current "periodic" connection mode, I do not expect this PR to be merged in the current state, I mostly want to start a discussion here. I'm aware that my implementation is not really backwards compatible with regards to folks that rely on the current periodic connection behavior.

I feel like the current "periodic" mode behaves like continuous with added retry mechanism in a loop, so this PR re-purposes and renames the "periodic" connection mode into a "temporary" connection mode which will close the connection to Roomba after the configurable "delay" timeout expires.

The motivation for this is to be able to use the Home Assistant's Roomba component to control the robot while de-prioritising the sensor updates. Their states will get updated as long as the current MQTT connection is kept open.

This was tested locally and works as expected with Roomba 690 model and Home Assistant 2026.7.2. This particular Roomba model has a quirk where as long as there is an active MQTT connection, all lights on the robot remain on (I'm not sure if this behavior is present on other models). This is something I wanted to fix and the effort ended up as this PR.

Do you feel like this could be somehow incorporated into this library? Obviously I'm open to any suggestions.