### PR TITLE
build: auto-install pre-commit hooks in nix develop

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,7 @@
             shellHook = ''
               export REPO_ROOT="$(git rev-parse --show-toplevel)"
               echo "roombapy dev shell (uv2nix, $(python --version))"
+              pre-commit install --install-hooks >/dev/null
             '';
           };
         }


### PR DESCRIPTION
## Summary

- `nix develop`'s shellHook now runs `pre-commit install --install-hooks` automatically, using the `pre-commit` binary already present in the uv2nix-built dev environment.
- `.pre-commit-config.yaml` stays the single source of truth (same file CI runs against via `uv run pre-commit run <hook> --all-files`) — no hook definitions duplicated into Nix (considered the full [git-hooks.nix](https://github.com/cachix/git-hooks.nix)-style declarative approach used in some of my other flakes, but that would mean two parallel hook definitions that could drift, since CI would still run the YAML file directly).

## Test plan

- [x] `nixfmt` / `statix check` clean.
- [x] `nix develop` installs `.git/hooks/pre-commit` (verified the generated hook file appears after a fresh shell entry with no prior hook installed).
- [x] Ironically, this is what caught that I'd been committing straight to `main` all session — the freshly-installed `no-commit-to-branch` hook blocked it, so this change itself went through a branch/PR instead.