### PR TITLE
New, verified RRTP protocoll ("Robot Realtime Positioning")

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,62 @@ has been received. Coverage is also deliberately partial beyond that: a key
 that is not declared is simply not typed, which is the right outcome for
 firmware-specific fields.
 
+## Live position (newer robots)
+
+900-series robots publish their position into the shadow. Newer ones do
+not — they answer when asked, over a request/response channel that
+nobody had documented until field captures from four robots across three
+firmware families settled it.
+
+```python
+# One reading
+pose = await client.get_position()
+if pose is not None:
+    print(pose.x, pose.y, pose.theta)  # metres, metres, radians
+
+# A stream
+async for pose in client.watch_position():
+    print(pose.x, pose.y)
+```
+
+**One stream, both generations.** `watch_position()` polls where it has
+to and reads the shadow where it can: a 900-series publishes its
+position, so it is never asked for one. `RobotPosition` is always
+**metres and radians**, origin at the dock, x-axis along the direction
+the robot faces when docked — a consumer does not need to know which
+generation it has.
+
+`pose.source` says anyway, because the cost differs: listening to a
+shadow is free, while every requested pose is a round trip.
+
+This is a different thing from `watch()`, which yields raw shadow
+messages — everything the robot reports, unparsed. `watch_position()`
+yields one kind of thing, already interpreted, and only when there is
+one.
+
+Three things worth knowing before building on it:
+
+- **`get_position()` returns `None` when the robot has no fix.** That is
+  a real state, not a failure — a Braava jet m6 answered that way for a
+  whole mission while a vacuum on the same account returned coordinates.
+- **`theta` wraps at π.** A field capture went from `3.06` to `-2.63`
+  across one turn. Anything computing heading deltas has to handle it;
+  the library reports what arrived rather than normalising.
+- **`watch_position()` raises `RrtpUnsupportedError`** after repeated
+  silence. Older generations do not implement the request, and an empty
+  stream would look like a finished mission instead of an unsupported
+  robot.
+
+The default poll interval is 1 Hz. 2 Hz was verified — 100 of 100
+requests answered on a moving robot — but that was a stress test, and a
+77-minute mission at that rate is roughly 9,200 requests against 4,600.
+At 1 Hz the point spacing is around 125 mm, comparable to the 132 mm a
+900-series publishes unprompted.
+
+Do **not** gate any of this on `cap.pose`. Neither the firmware nor the
+vendor app ever compares that value, and lewis hard-codes it to 2;
+support is established by asking and handling silence.
+
 ## Upgrading from 1.x
 
 Version 2 is asynchronous throughout, and breaking.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ requests answered on a moving robot — but that was a stress test, and a
 At 1 Hz the point spacing is around 125 mm, comparable to the 132 mm a
 900-series publishes unprompted.
 
+**One poller serves every watcher**, at the shortest interval any of
+them asked for. A second caller asking for a faster rate restarts it;
+when that caller leaves, it drops back. The robot allows one local
+connection, so two callers running their own loops would double its
+load without either noticing.
+
 Do **not** gate any of this on `cap.pose`. Neither the firmware nor the
 vendor app ever compares that value, and lewis hard-codes it to 2;
 support is established by asking and handling silence.

--- a/roombapy/__init__.py
+++ b/roombapy/__init__.py
@@ -25,6 +25,7 @@ from roombapy.roomba import (
     TransportOptions,
 )
 from roombapy.roomba_info import RoombaInfo
+from roombapy.rrtp import RobotPosition, RrtpUnsupportedError
 from roombapy.state import RoombaStateMachine
 from roombapy.tls import generate_tls_context
 from roombapy.types import (
@@ -74,6 +75,7 @@ __all__ = [
     "PosePoint",
     "ReportedState",
     "ResetInfo",
+    "RobotPosition",
     "RoombaAuthError",
     "RoombaClient",
     "RoombaConnectionError",
@@ -84,6 +86,7 @@ __all__ = [
     "RoombaPassword",
     "RoombaScopeError",
     "RoombaStateMachine",
+    "RrtpUnsupportedError",
     "RunStats",
     "SignalState",
     "State",

--- a/roombapy/roomba.py
+++ b/roombapy/roomba.py
@@ -182,12 +182,23 @@ class RoombaClient:
         #: Outstanding position requests, matched by reqId.
         self._rrtp = rrtp.RrtpRequests()
         #: One poller feeds however many position watchers there are.
-        self._position_watchers: set[asyncio.Queue[rrtp.RobotPosition]] = set()
+        #: Mapped to the interval each asked for, so the poller can drop
+        #: back to a slower rate when a fast watcher leaves.
+        self._position_watchers: dict[
+            asyncio.Queue[rrtp.RobotPosition], float
+        ] = {}
         self._position_poller: asyncio.Task[None] | None = None
         #: Set once a shadow pose arrives. Latching rather than
         #: re-checking: a robot that has published once will publish
         #: again, and this must survive a quiet moment mid-mission.
         self._shadow_publishes_pose = False
+        #: Interval the shared poller currently runs at.
+        self._position_interval = float("inf")
+        #: Set once this robot has failed to answer position requests.
+        #: Cleared on disconnect, because a firmware update that adds
+        #: the capability brings a reconnect with it -- a permanent
+        #: "cannot" would outlive the reason for it.
+        self._position_unsupported = False
         self._closed_event = asyncio.Event()
 
     # ------------------------------------------------------------------
@@ -313,6 +324,19 @@ class RoombaClient:
         finally:
             self._watchers.discard(queue)
 
+    def _forget_position_capabilities(self) -> None:
+        """Drop what this connection learned about the robot.
+
+        Both flags describe the robot as seen over one session: whether
+        it publishes a pose, and whether it answered requests. A
+        firmware update that changes either brings a reconnect with it,
+        so neither verdict should outlive the connection that produced
+        it.
+        """
+        self._rrtp.cancel_all()
+        self._position_unsupported = False
+        self._shadow_publishes_pose = False
+
     def _feed_position_watchers(self, pose: rrtp.RobotPosition) -> None:
         """Hand a position to everyone listening, whichever path found it."""
         for queue in self._position_watchers:
@@ -386,6 +410,10 @@ class RoombaClient:
             with contextlib.suppress(asyncio.CancelledError):
                 await task
         self._connected = False
+        # PENDING REQUESTS DIE WITH THE CONNECTION. A caller awaiting a
+        # position when the client shuts down would otherwise sit on a
+        # future nothing can ever resolve.
+        self._forget_position_capabilities()
         self._closed_event.set()
 
         # Give callbacks already in flight a chance to finish. A consumer
@@ -514,6 +542,10 @@ class RoombaClient:
                     await self._notify_disconnect("internal error")
             finally:
                 self._connected = False
+                # Same on an unexpected drop: the reply for anything
+                # in flight was going to arrive on a socket that no
+                # longer exists.
+                self._forget_position_capabilities()
                 self._client = None
 
             if self._closing:
@@ -745,13 +777,32 @@ class RoombaClient:
         vendor app ever compares that value; lewis hard-codes it to 2.
         Support is established by asking and handling silence.
         """
+        # THE SHADOW FIRST, if there is one. A 900-series publishes its
+        # position and never answers a request -- asking anyway would
+        # hand the caller a TimeoutError for data already in hand.
+        #
+        # `watch_position()` gets this right by listening before it
+        # polls; a single call has no such window, so it reads what has
+        # already arrived.
+        reported = self.master_state.get("state", {}).get("reported", {})
+        raw_pose = reported.get("pose")
+        if isinstance(raw_pose, dict):
+            pose = rrtp.pose_from_shadow(raw_pose)
+            if pose is not None:
+                return pose
+
         req_id, future = self._rrtp.new_request()
         payload = orjson.dumps(rrtp.build_request(req_id)).decode("utf-8")
         try:
             await self._publish(rrtp.REQUEST_TOPIC, payload)
             async with asyncio.timeout(timeout):
                 return await future
-        except (TimeoutError, asyncio.CancelledError):
+        except BaseException:
+            # EVERY failure, not just timeout and cancellation. A
+            # `_publish` that raises -- not connected, broker gone --
+            # would otherwise leave the request in `_pending` for the
+            # lifetime of the client, and a poller retrying once a
+            # second would accumulate them.
             self._rrtp.abandon(req_id)
             raise
 
@@ -796,26 +847,168 @@ class RoombaClient:
             )
             raise ValueError(msg)
 
+        if self._position_unsupported:
+            # ASKED AND ANSWERED. Without this, a dashboard opening and
+            # closing a map view would spend three requests and a grace
+            # period each time, against a robot already known not to
+            # answer.
+            msg = (
+                f"{self.address} did not answer position requests "
+                f"earlier in this connection"
+            )
+            raise rrtp.RrtpUnsupportedError(msg)
+
         queue: asyncio.Queue[rrtp.RobotPosition] = asyncio.Queue(
             maxsize=maxsize
         )
-        self._position_watchers.add(queue)
-        if self._position_poller is None or self._position_poller.done():
+        self._position_watchers[queue] = interval
+        # THE FASTEST REQUEST WINS. One poller serves every watcher, so
+        # a second caller asking for a shorter interval would otherwise
+        # be silently given the first caller's slower one -- and would
+        # see a sparser trail than it asked for with nothing to explain
+        # why.
+        #
+        # Restarting is cheap: the existing watchers keep their queues,
+        # and the new poller feeds all of them.
+        wanted = min(self._position_watchers.values())
+        faster = wanted < self._position_interval
+        self._position_interval = wanted
+        stale = self._position_poller is None or self._position_poller.done()
+        if stale or faster:
+            if self._position_poller is not None:
+                self._position_poller.cancel()
             self._position_poller = asyncio.ensure_future(
-                self._run_position_poller(interval, timeout)
+                self._run_position_poller(timeout)
             )
         try:
-            while True:
-                yield await queue.get()
+            async for pose in self._drain_positions(queue, timeout):
+                yield pose
         finally:
-            self._position_watchers.discard(queue)
-            if not self._position_watchers and self._position_poller:
-                self._position_poller.cancel()
-                self._position_poller = None
+            self._position_watchers.pop(queue, None)
+            if not self._position_watchers:
+                if self._position_poller is not None:
+                    # AWAITED, NOT JUST CANCELLED. `cancel()` only
+                    # requests it; the task stays pending until the
+                    # loop gets round to it, so a caller that closes a
+                    # stream and then tears down its event loop leaves
+                    # a task behind.
+                    #
+                    # Five tests had to clean this up by hand, which is
+                    # the library asking its callers to finish a job it
+                    # started.
+                    poller, self._position_poller = (
+                        self._position_poller,
+                        None,
+                    )
+                    poller.cancel()
+                    with contextlib.suppress(
+                        asyncio.CancelledError, Exception
+                    ):
+                        await poller
+                # Reset, or the next stream inherits a rate nobody asked
+                # for from a caller that has long gone.
+                self._position_interval = float("inf")
+            else:
+                # A FAST WATCHER LEAVING SHOULD SLOW THE POLLER BACK
+                # DOWN. Otherwise one caller asking for 0.5 s leaves
+                # everyone else paying for that rate after it has gone.
+                self._position_interval = min(self._position_watchers.values())
+
+    def _restart_poller(
+        self,
+        stale: asyncio.Task[None],
+        timeout: float,
+    ) -> None:
+        """Start a replacement poller, unless another watcher already did.
+
+        TWO WATCHERS WAKE ON THE SAME DEAD POLLER. Both would assign to
+        `_position_poller`, the second overwriting the first -- whose
+        task keeps running unreferenced. That is two pollers asking the
+        same robot twice as often, which is the exact thing one shared
+        poller exists to prevent.
+
+        Comparing against the task the caller saw makes the second
+        caller a no-op.
+        """
+        if self._position_poller is not stale:
+            return
+        self._position_poller = asyncio.ensure_future(
+            self._run_position_poller(timeout)
+        )
+
+    def _poller_ended_recoverably(self, poller: asyncio.Task[None]) -> bool:
+        """Decide whether the stream carries on after the poller stopped.
+
+        Two ways a poller ends without anything being wrong: the robot
+        turned out to publish, so the shadow feeds the stream instead;
+        or the connection dropped and `_supervise` is rebuilding it.
+
+        Returning True for the second is what keeps a reconnect from
+        looking like a completed mission.
+        """
+        if not poller.cancelled():
+            poller.result()  # re-raises whatever it hit
+        if self._shadow_publishes_pose:
+            return True
+        return self._connected or not self._closed_event.is_set()
+
+    async def _drain_positions(
+        self,
+        queue: asyncio.Queue[rrtp.RobotPosition],
+        timeout: float,  # noqa: ASYNC109
+    ) -> AsyncIterator[rrtp.RobotPosition]:
+        """Yield from the queue while watching the poller for failures.
+
+        Split out of `watch_position` so the setup and the loop can be
+        read separately; the cleanup stays with the caller.
+        """
+        while True:
+            # RACE THE POLLER, do not just wait on the queue.
+            #
+            # A bare `await queue.get()` hangs forever when the
+            # poller raises: the exception dies inside the task and
+            # the consumer waits for a position that will never
+            # come. RrtpUnsupportedError exists precisely so a
+            # consumer finds out, and swallowing it here would
+            # defeat the whole point.
+            poller = self._position_poller
+            if poller is None or poller.done():
+                if poller is None or not self._poller_ended_recoverably(
+                    poller
+                ):
+                    return
+                if self._shadow_publishes_pose:
+                    yield await queue.get()
+                    continue
+                self._restart_poller(poller, timeout)
+                continue
+            getter = asyncio.ensure_future(queue.get())
+            try:
+                done, _pending = await asyncio.wait(
+                    {getter, poller},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+            except BaseException:
+                # THE GETTER OUTLIVES A CANCELLED CONSUMER OTHERWISE.
+                # `asyncio.wait` does not cancel what it was waiting
+                # on, so a consumer cancelled mid-await leaves a
+                # queue.get() pending on the event loop forever.
+                getter.cancel()
+                raise
+            if getter in done:
+                yield getter.result()
+                continue
+            getter.cancel()
+            # SAME DECISION AS ABOVE. This branch used to return
+            # unconditionally, so a reconnect ended the stream here even
+            # after the other path learned not to.
+            if not self._poller_ended_recoverably(poller):
+                return
+            if not self._shadow_publishes_pose:
+                self._restart_poller(poller, timeout)
 
     async def _run_position_poller(
         self,
-        interval: float,
         timeout: float,  # noqa: ASYNC109
     ) -> None:
         """Ask repeatedly, feed every watcher, stop when nobody listens."""
@@ -847,6 +1040,7 @@ class RoombaClient:
                 # Without this the stream would poll a generation that
                 # cannot answer every half second until the mission ends.
                 if misses >= _UNSUPPORTED_AFTER:
+                    self._position_unsupported = True
                     for queue in self._position_watchers:
                         _drop_oldest_if_full(queue)
                     msg = (
@@ -860,7 +1054,10 @@ class RoombaClient:
                 misses = 0
             if pose is not None:
                 self._feed_position_watchers(pose)
-            await asyncio.sleep(interval)
+            # Re-read each pass: a watcher joining or leaving changes
+            # the shared rate, and the poller should follow rather than
+            # keep the value it was started with.
+            await asyncio.sleep(self._position_interval)
 
     async def _publish(self, topic: str, payload: str) -> None:
         client = self._client

--- a/roombapy/roomba.py
+++ b/roombapy/roomba.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, Literal, Self, cast
 import aiomqtt
 import orjson
 
+from roombapy import rrtp
 from roombapy.state import RoombaMessage, RoombaStateMachine
 from roombapy.tls import generate_tls_context
 
@@ -41,6 +42,41 @@ __all__ = [
     "RoombaScopeError",
     "TransportOptions",
 ]
+
+#: Fastest position poll a caller may ask for.
+#:
+#: 0.5 s is the only rate anyone has verified: 100 of 100 requests
+#: answered on a moving i7+, latencies 0.24-0.78 s. That was a STRESS
+#: TEST rather than a recommendation -- @Thonno picked it to see whether
+#: the robot would hold up and whether a rate limit existed, and it is
+#: the ceiling of what is known to work, not a suggestion.
+#:
+#: The floor keeps a caller from finding the real limit on somebody
+#: else's hardware.
+_MIN_POSITION_INTERVAL = 0.5
+
+#: Default poll interval.
+#:
+#: 1 Hz rather than the 2 Hz that was tested, because the tested figure
+#: was a stress test. Over a 77-minute mission that is ~4,600 requests
+#: instead of ~9,200, and the resulting spacing is still around 125 mm
+#: -- comparable to the 132 mm a 900-series publishes unprompted.
+#:
+#: Callers who want the denser trail can ask for it; the default should
+#: not be the hardest thing the robot survived.
+_DEFAULT_POSITION_INTERVAL = 1.0
+
+#: How long to wait for the robot to publish a pose before asking for
+#: one. Generous on purpose: whichever generation this is, it settles
+#: the question in a couple of seconds, and getting it wrong the other
+#: way means polling a robot that was already telling us.
+_SHADOW_GRACE = 3.0
+
+#: Silent replies before the stream declares the robot incapable.
+#: Three rather than one, because a single miss can be a dropped
+#: connection -- and three costs a second and a half rather than the
+#: rest of a mission.
+_UNSUPPORTED_AFTER = 3
 
 MAX_CONNECTION_RETRIES = 3
 RECONNECT_BACKOFF_MIN = 1.0
@@ -143,6 +179,15 @@ class RoombaClient:
         self.auth_error: RoombaAuthError | None = None
         self._pending_callbacks: set[asyncio.Task[None]] = set()
         self._watchers: set[asyncio.Queue[RoombaMessage]] = set()
+        #: Outstanding position requests, matched by reqId.
+        self._rrtp = rrtp.RrtpRequests()
+        #: One poller feeds however many position watchers there are.
+        self._position_watchers: set[asyncio.Queue[rrtp.RobotPosition]] = set()
+        self._position_poller: asyncio.Task[None] | None = None
+        #: Set once a shadow pose arrives. Latching rather than
+        #: re-checking: a robot that has published once will publish
+        #: again, and this must survive a quiet moment mid-mission.
+        self._shadow_publishes_pose = False
         self._closed_event = asyncio.Event()
 
     # ------------------------------------------------------------------
@@ -267,6 +312,12 @@ class RoombaClient:
                 yield get.result()
         finally:
             self._watchers.discard(queue)
+
+    def _feed_position_watchers(self, pose: rrtp.RobotPosition) -> None:
+        """Hand a position to everyone listening, whichever path found it."""
+        for queue in self._position_watchers:
+            _drop_oldest_if_full(queue)
+            queue.put_nowait(pose)
 
     def _feed_watchers(self, message: RoombaMessage) -> None:
         for queue in self._watchers:
@@ -530,6 +581,38 @@ class RoombaClient:
             )
             return
 
+        # A REPLY IS NOT STATE, and this has to come before apply().
+        #
+        # The rrtp response carries `reportType`, `reqId` and `data` at
+        # the top level. dict_merge would file them alongside `state`,
+        # where every consumer reading master_state would see them --
+        # briefly, until the next shadow update, which is long enough to
+        # be read as robot state.
+        if topic == rrtp.RESPONSE_TOPIC:
+            self._rrtp.resolve(decoded)
+            return
+
+        # A SHADOW POSE FEEDS THE SAME STREAM. A 900-series publishes
+        # its position rather than answering for it, and a consumer
+        # should not have to know which generation it has -- that is the
+        # whole point of RobotPosition carrying `source`.
+        # NOT gated on there being watchers: the flag has to be set
+        # whether or not anyone is listening yet, or a stream opened
+        # later starts a poller for a robot that has been publishing
+        # all along.
+        reported = (decoded.get("state") or {}).get("reported") or {}
+        raw_pose = reported.get("pose")
+        if isinstance(raw_pose, dict):
+            pose = rrtp.pose_from_shadow(raw_pose)
+            if pose is not None:
+                self._shadow_publishes_pose = True
+                # A poller that started before the first shadow message
+                # has its answer now.
+                if self._position_poller is not None:
+                    self._position_poller.cancel()
+                    self._position_poller = None
+                self._feed_position_watchers(pose)
+
         self._state.apply(decoded)
 
         # Periodically re-derive everything from the accumulated state, as the
@@ -641,6 +724,144 @@ class RoombaClient:
         payload = orjson.dumps({"state": {preference: value}}).decode("utf-8")
         await self._publish("delta", payload)
 
+    async def get_position(
+        self,
+        *,
+        # A ROBOT-SHAPED DEADLINE, not a caller-shaped one. Silence here
+        # means the generation does not implement the request, so the
+        # value is protocol knowledge rather than caller preference --
+        # same reasoning as discovery's timeouts.
+        timeout: float = 5.0,  # noqa: ASYNC109
+    ) -> rrtp.RobotPosition | None:
+        """Ask the robot where it is.
+
+        Returns None when the robot answered but has no fix -- a real
+        state, not a failure. Raises TimeoutError when nothing comes
+        back, which on this protocol means the robot does not implement
+        the request rather than that it was busy: field captures show
+        100 of 100 answered at 2 Hz on a moving robot.
+
+        DO NOT gate this on `cap.pose`. Neither the firmware nor the
+        vendor app ever compares that value; lewis hard-codes it to 2.
+        Support is established by asking and handling silence.
+        """
+        req_id, future = self._rrtp.new_request()
+        payload = orjson.dumps(rrtp.build_request(req_id)).decode("utf-8")
+        try:
+            await self._publish(rrtp.REQUEST_TOPIC, payload)
+            async with asyncio.timeout(timeout):
+                return await future
+        except (TimeoutError, asyncio.CancelledError):
+            self._rrtp.abandon(req_id)
+            raise
+
+    async def watch_position(
+        self,
+        *,
+        interval: float = _DEFAULT_POSITION_INTERVAL,
+        timeout: float = 5.0,  # noqa: ASYNC109
+        maxsize: int = 10,
+    ) -> AsyncIterator[rrtp.RobotPosition]:
+        """Yield the robot's position for as long as anyone is listening.
+
+        THE INTERVAL BELONGS HERE, not to the caller. The robot accepts
+        one local connection, and two callers running their own loops
+        would double the load without either noticing. One poller feeds
+        every watcher, and the last one to leave stops it.
+
+        The default is 1 Hz. 2 Hz was verified -- 100 of 100 requests
+        answered on a moving i7+ -- but that was a stress test rather
+        than a recommendation, and a 77-minute mission at that rate is
+        roughly 9,200 requests against 4,600 at 1 Hz.
+
+        At 1 Hz the spacing works out around 125 mm between points,
+        comparable to the 132 mm a 900-series publishes unprompted. Ask
+        for 0.5 if you want the denser trail and have decided the
+        traffic is worth it.
+
+        NOT measured across a whole mission at any rate. The longest
+        verified run was fifty seconds.
+
+        Poses with no fix are skipped rather than yielded as None: a
+        stream of positions should carry positions, and a Braava jet m6
+        produced nothing else for a whole run.
+
+        Raises RrtpUnsupportedError after repeated silence, so a
+        consumer finds out rather than watching an empty map.
+        """
+        if interval < _MIN_POSITION_INTERVAL:
+            msg = (
+                f"interval {interval}s is below the {_MIN_POSITION_INTERVAL}s "
+                f"floor; no robot has been tested faster than 2 Hz"
+            )
+            raise ValueError(msg)
+
+        queue: asyncio.Queue[rrtp.RobotPosition] = asyncio.Queue(
+            maxsize=maxsize
+        )
+        self._position_watchers.add(queue)
+        if self._position_poller is None or self._position_poller.done():
+            self._position_poller = asyncio.ensure_future(
+                self._run_position_poller(interval, timeout)
+            )
+        try:
+            while True:
+                yield await queue.get()
+        finally:
+            self._position_watchers.discard(queue)
+            if not self._position_watchers and self._position_poller:
+                self._position_poller.cancel()
+                self._position_poller = None
+
+    async def _run_position_poller(
+        self,
+        interval: float,
+        timeout: float,  # noqa: ASYNC109
+    ) -> None:
+        """Ask repeatedly, feed every watcher, stop when nobody listens."""
+        # LISTEN BEFORE ASKING. A 900-series publishes its position, and
+        # `_handle_message` already feeds those into the same stream --
+        # so polling one would add traffic for data arriving for free,
+        # and would then raise RrtpUnsupportedError and kill a stream
+        # that was working.
+        #
+        # Waiting decides on what ARRIVES rather than on `cap.pose`,
+        # which is a compile-time constant on lewis and has never been
+        # compared against anything by either the firmware or the app.
+        # A robot that publishes does so within a second or two; this
+        # costs one delayed first point per stream.
+        await asyncio.sleep(_SHADOW_GRACE)
+        if self._shadow_publishes_pose:
+            return
+
+        misses = 0
+        while self._position_watchers:
+            try:
+                pose = await self.get_position(timeout=timeout)
+            except TimeoutError:
+                misses += 1
+                # THREE SILENT REQUESTS ARE NOT A HICCUP. Across 100
+                # consecutive requests on a moving robot there was not
+                # one miss -- a robot answers or it never does.
+                #
+                # Without this the stream would poll a generation that
+                # cannot answer every half second until the mission ends.
+                if misses >= _UNSUPPORTED_AFTER:
+                    for queue in self._position_watchers:
+                        _drop_oldest_if_full(queue)
+                    msg = (
+                        f"{self.address} did not answer "
+                        f"{_UNSUPPORTED_AFTER} position requests; this "
+                        f"robot does not implement rrtp position"
+                    )
+                    raise rrtp.RrtpUnsupportedError(msg) from None
+                continue
+            else:
+                misses = 0
+            if pose is not None:
+                self._feed_position_watchers(pose)
+            await asyncio.sleep(interval)
+
     async def _publish(self, topic: str, payload: str) -> None:
         client = self._client
         if client is None or not self._connected:
@@ -704,6 +925,17 @@ async def _guard(awaitable: Awaitable[Any], log: logging.Logger) -> None:
         await awaitable
     except Exception:
         log.exception("Error in Roomba callback")
+
+
+def _drop_oldest_if_full(queue: asyncio.Queue[Any]) -> None:
+    """Make room in a full queue, oldest first.
+
+    Same policy as watch(): a slow consumer loses the stalest position
+    rather than stalling the poller for everyone else.
+    """
+    if queue.full():
+        with contextlib.suppress(asyncio.QueueEmpty):
+            queue.get_nowait()
 
 
 def _decode_payload(raw_payload: bytes) -> RoombaMessage | None:

--- a/roombapy/rrtp.py
+++ b/roombapy/rrtp.py
@@ -173,7 +173,7 @@ _PARSERS: dict[str, Callable[[dict[str, Any]], RobotPosition | None]] = {
 
 
 def parse_response(decoded: dict[str, Any]) -> RobotPosition | None:
-    """Turn a reply into a Pose, or None when there is no position."""
+    """Turn a reply into a RobotPosition, or None when there is no fix."""
     version = decoded.get("ver")
     parser = _PARSERS.get(str(version))
     if parser is None:
@@ -187,7 +187,7 @@ def parse_response(decoded: dict[str, Any]) -> RobotPosition | None:
 
 
 def pose_from_shadow(pose: dict[str, Any]) -> RobotPosition | None:
-    """Convert a 900-series shadow `pose` into the same Pose.
+    """Convert a 900-series shadow `pose` into a RobotPosition.
 
     The shadow reports `{"theta": 153, "point": {"x": -16, "y": 243}}`
     -- integer millimetres and degrees. Same origin and same axis as the

--- a/roombapy/rrtp.py
+++ b/roombapy/rrtp.py
@@ -1,0 +1,273 @@
+"""Real-time position requests (rrtp).
+
+Newer robots do not publish their position. They answer when asked:
+publish to `req`, the reply arrives on `data`, matched by `reqId`.
+
+Confirmed against four robots across three firmware families -- lewis
+(i7+, two S9+), sanmarino (Braava jet m6) and daredevil (i3). The topic
+name came from the app's own initialiser; everything else came off the
+wire.
+
+    request   req    {"reqId": "...", "reqType": "current",
+                      "conType": "local"}
+    reply     data   {"reportType": "current", "reqId": <echo>,
+                      "ver": "1.0.0",
+                      "data": [{"pmap_id": ..., "pmapv_id": ...,
+                                "coords": [{"type": "current",
+                                            "xyt": [x_m, y_m, theta_rad],
+                                            "ts": <unix>}]}]}
+
+Only `reqType: "current"` is implemented on lewis. `historical`,
+`update` and `adjustment` are in the firmware's enum, are checked, and
+are rejected -- verified on hardware, not assumed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUEST_TOPIC = "req"
+RESPONSE_TOPIC = "data"
+
+#: The only request type any robot has been seen to implement.
+REQUEST_TYPE_CURRENT = "current"
+
+#: `local` and `remote` are both valid firmware literals. A robot
+#: answers either over a local connection, so `conType` is not the
+#: routing switch its name suggests -- but sending the honest one costs
+#: nothing.
+CONNECTION_TYPE_LOCAL = "local"
+
+
+class RrtpUnsupportedError(Exception):
+    """Raised when a robot does not answer position requests.
+
+    Raised by the position stream after repeated silence, so a consumer
+    finds out rather than watching an empty map. A single request that
+    times out raises nothing -- that is the caller's to interpret.
+    """
+
+
+@dataclass(frozen=True)
+class RobotPosition:
+    """Where the robot is, however that was obtained.
+
+    NAMED APART FROM `types.Pose` ON PURPOSE. That one is the raw shadow
+    shape -- a TypedDict of integer millimetres and degrees, exactly as
+    the 900-series sends it. This is the interpreted form: floats,
+    metres and radians, and a `source` saying which path produced it.
+    Two names because they are two things, and collapsing them would
+    hide a unit change behind a shared type.
+
+    ALWAYS metres and radians, origin at the dock, x-axis along the
+    direction the robot faces when docked.
+
+    A 900-series publishes `pose` into its shadow as integer millimetres
+    and degrees; lewis and later answer in metres and radians on
+    request. Same frame, different units -- and if every caller converts
+    for itself, every caller writes the same conversion and one of them
+    gets a sign wrong.
+
+    `source` says where it came from. Not for the geometry, which is
+    identical, but because the COST differs: listening to a shadow is
+    free, while every requested pose costs a round trip. A consumer
+    choosing a poll interval needs to know whether it is paying for one.
+
+    `theta` WRAPS AT PI. A field capture went from 3.06 to -2.63 across
+    one turn. Anything computing heading deltas has to handle that, or
+    it reads a 30-degree turn as a 330-degree one. Not normalised here:
+    the library reports what arrived.
+    """
+
+    x: float
+    y: float
+    theta: float
+    timestamp: int
+    source: Literal["shadow", "request"]
+    #: Which saved floorplan the coordinates belong to. Only the
+    #: requested path carries these; the shadow keeps its map id
+    #: elsewhere, and inventing a value here would be worse than None.
+    pmap_id: str | None = None
+    pmapv_id: str | None = None
+
+
+def build_request(req_id: str) -> dict[str, str]:
+    """Build the request body, exactly as the app sends it."""
+    return {
+        "reqId": req_id,
+        "reqType": REQUEST_TYPE_CURRENT,
+        "conType": CONNECTION_TYPE_LOCAL,
+    }
+
+
+def _first_dict(value: Any) -> dict[str, Any] | None:
+    """First element of a list, when it is a dict; otherwise None."""
+    if not isinstance(value, list) or not value:
+        return None
+    first = value[0]
+    return first if isinstance(first, dict) else None
+
+
+def _parse_v1(decoded: dict[str, Any]) -> RobotPosition | None:
+    """Parse a `ver: 1.0.0` reply.
+
+    Returns None when the robot answered but has no fix -- `type:
+    "unknown"` with no `xyt`. That is a real state, not a failure: a
+    Braava jet m6 produced it consistently while a vacuum on the same
+    account returned coordinates.
+    """
+    first = _first_dict(decoded.get("data"))
+    if first is None:
+        return None
+    coord = _first_dict(first.get("coords"))
+    if coord is None:
+        return None
+
+    xyt = coord.get("xyt")
+    # LENGTH-CHECKED, not just truthy. `type: "unknown"` omits the key
+    # entirely, but a short or malformed list must not unpack.
+    if not isinstance(xyt, (list, tuple)) or len(xyt) != 3:
+        return None
+
+    try:
+        x, y, theta = (float(v) for v in xyt)
+        ts = int(coord.get("ts", 0))
+    except (TypeError, ValueError):
+        _LOGGER.debug("rrtp: unparsable coordinates %r", xyt)
+        return None
+
+    return RobotPosition(
+        x=x,
+        y=y,
+        theta=theta,
+        timestamp=ts,
+        source="request",
+        pmap_id=first.get("pmap_id"),
+        pmapv_id=first.get("pmapv_id"),
+    )
+
+
+#: Keyed on the `ver` the robot puts in its reply.
+#:
+#: The client cannot ASK for a version -- the request carries none, and
+#: the robot picks from its own registry. lewis has exactly "1.0.0"
+#: registered, and rejects anything else with a message parameterised by
+#: version, which only makes sense if others can exist.
+#:
+#: One entry looks like over-engineering until a robot answers "2.0.0".
+#: Then it is a line rather than a rewrite, and until then an unknown
+#: version is logged instead of being misread as a known one.
+_PARSERS: dict[str, Callable[[dict[str, Any]], RobotPosition | None]] = {
+    "1.0.0": _parse_v1,
+}
+
+
+def parse_response(decoded: dict[str, Any]) -> RobotPosition | None:
+    """Turn a reply into a Pose, or None when there is no position."""
+    version = decoded.get("ver")
+    parser = _PARSERS.get(str(version))
+    if parser is None:
+        _LOGGER.info(
+            "rrtp: reply version %r is not supported by this library; "
+            "the response shape is unknown and will not be guessed at",
+            version,
+        )
+        return None
+    return parser(decoded)
+
+
+def pose_from_shadow(pose: dict[str, Any]) -> RobotPosition | None:
+    """Convert a 900-series shadow `pose` into the same Pose.
+
+    The shadow reports `{"theta": 153, "point": {"x": -16, "y": 243}}`
+    -- integer millimetres and degrees. Same origin and same axis as the
+    requested form, so only the units differ.
+
+    Converting here rather than in each consumer is the whole point: it
+    is one formula, and five callers would write it five times.
+    """
+    point = pose.get("point")
+    if not isinstance(point, dict):
+        return None
+    try:
+        x_mm = float(point["x"])
+        y_mm = float(point["y"])
+        theta_deg = float(pose["theta"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    return RobotPosition(
+        x=x_mm / 1000.0,
+        y=y_mm / 1000.0,
+        theta=math.radians(theta_deg),
+        timestamp=0,  # the shadow carries no timestamp for the pose
+        source="shadow",
+    )
+
+
+class RrtpRequests:
+    """Outstanding requests, matched by `reqId`.
+
+    MATCHED BY ID, never by arrival order. Replies could in principle
+    come back out of order, and assuming otherwise is how a request
+    quietly resolves with somebody else's position.
+
+    Holds no state beyond an in-flight request: a caller that stops
+    waiting leaves nothing behind.
+    """
+
+    def __init__(self) -> None:
+        """Start with nothing outstanding."""
+        self._pending: dict[str, asyncio.Future[RobotPosition | None]] = {}
+
+    def new_request(self) -> tuple[str, asyncio.Future[RobotPosition | None]]:
+        """Register a request and return its id and future."""
+        req_id = uuid.uuid4().hex[:12]
+        future: asyncio.Future[RobotPosition | None] = (
+            asyncio.get_running_loop().create_future()
+        )
+        self._pending[req_id] = future
+        return req_id, future
+
+    def resolve(self, decoded: dict[str, Any]) -> bool:
+        """Deliver a reply to whoever asked for it.
+
+        Returns True when the reply matched an outstanding request. An
+        unmatched reply is dropped rather than resolving an arbitrary
+        future -- it may be an answer to a request that already timed
+        out, or to another client on the same broker.
+        """
+        req_id = str(decoded.get("reqId", ""))
+        future = self._pending.pop(req_id, None)
+        if future is None:
+            _LOGGER.debug("rrtp: reply for unknown reqId %r, dropped", req_id)
+            return False
+        if not future.done():
+            future.set_result(parse_response(decoded))
+        return True
+
+    def abandon(self, req_id: str) -> None:
+        """Forget a request whose caller has given up."""
+        self._pending.pop(req_id, None)
+
+    def cancel_all(self) -> None:
+        """Fail every outstanding request; used on disconnect."""
+        for future in self._pending.values():
+            if not future.done():
+                future.cancel()
+        self._pending.clear()
+
+    @property
+    def in_flight(self) -> int:
+        """How many requests are waiting for a reply."""
+        return len(self._pending)

--- a/tests/test_rrtp.py
+++ b/tests/test_rrtp.py
@@ -116,7 +116,7 @@ class TestBothGenerationsAgree:
         assert pose.theta == pytest.approx(math.radians(153))
 
     def test_source_still_tells_them_apart(self) -> None:
-        """Unifying the units must not hide the cost difference:.
+        """Unifying the units must not hide the cost difference.
 
         listening to a shadow is free, every requested pose is a round
         trip.
@@ -135,7 +135,7 @@ class TestBothGenerationsAgree:
 
 
 class TestThetaWrapIsNotSmoothed:
-    """@Thonno's rate run caught a turn in place crossing pi:.
+    """A turn in place crossing pi, from a real rate run.
 
         -1.43 -> -0.53 -> 0.53 -> 1.33 -> 1.97 -> 2.40 -> 3.06 -> -2.63
 
@@ -208,7 +208,7 @@ class TestRequestMatching:
 
 
 class TestTheRequestBody:
-    """What goes out on ."""
+    """What goes out on the request topic."""
 
     def test_it_matches_what_the_app_sends(self) -> None:
         """Three fields, no more."""

--- a/tests/test_rrtp.py
+++ b/tests/test_rrtp.py
@@ -1,0 +1,234 @@
+"""Tests for the rrtp position request path.
+
+Every payload here is a real field capture, not an invented one. Four
+robots across three firmware families produced them, and the shapes that
+matter -- a no-fix reply, a docked reading, the wrap at pi -- came from
+runs nobody designed to produce them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+
+import pytest
+from roombapy import rrtp
+
+# @Thonno's i7+, parked on its dock. The -0.01 is the useful part: a
+# hardcoded docked value would read exactly zero.
+DOCKED = {
+    "reportType": "current",
+    "reqId": "probe-1",
+    "ver": "1.0.0",
+    "data": [
+        {
+            "pmap_id": "tM_GAKM5SmyBhqotQtQrtw",
+            "pmapv_id": "260901T194353",
+            "coords": [
+                {"type": "current", "xyt": [-0.01, 0.0, 0.0], "ts": 1788292259}
+            ],
+        }
+    ],
+}
+
+# @ScenicSystemsLLC's Braava jet m6, mid-mission. It answered, echoed the
+# id, named the map -- and had no position. `type: "unknown"`, no `xyt`.
+NO_FIX = {
+    "reportType": "current",
+    "reqId": "probe-1",
+    "ver": "1.0.0",
+    "data": [
+        {
+            "pmap_id": "jUdHT1VfTZCaZklWE-_6tw",
+            "pmapv_id": "260825T211448",
+            "coords": [{"type": "unknown", "ts": 1788288769}],
+        }
+    ],
+}
+
+
+class TestParsingRealReplies:
+    """Real captures, parsed."""
+
+    def test_a_docked_reading(self) -> None:
+        """A real reply from a docked robot."""
+        pose = rrtp.parse_response(DOCKED)
+
+        assert pose is not None
+        assert (pose.x, pose.y, pose.theta) == (-0.01, 0.0, 0.0)
+        assert pose.timestamp == 1788292259
+        assert pose.source == "request"
+        assert pose.pmap_id == "tM_GAKM5SmyBhqotQtQrtw"
+
+    def test_no_fix_is_none_not_an_exception(self) -> None:
+        """`type: "unknown"` is an answer, not a failure.
+
+        A Braava produced nothing else for a whole mission. Raising here
+        would force every caller into a try/except it does not want.
+        """
+        assert rrtp.parse_response(NO_FIX) is None
+
+    def test_an_unknown_version_is_not_guessed_at(self) -> None:
+        """Reject a version this library does not know.
+
+        The client cannot ask for one -- the robot picks from its own
+        registry. An unfamiliar version means an unknown response shape,
+        and reading it as 1.0.0 would invent coordinates.
+        """
+        reply = dict(DOCKED, ver="2.0.0")
+
+        assert rrtp.parse_response(reply) is None
+
+    def test_a_short_xyt_does_not_unpack(self) -> None:
+        """A malformed list must not raise.
+
+        Length-checked rather than truthy, because this runs inside the
+        message handler.
+        """
+        reply = {
+            "ver": "1.0.0",
+            "data": [{"coords": [{"type": "current", "xyt": [1.0, 2.0]}]}],
+        }
+
+        assert rrtp.parse_response(reply) is None
+
+
+class TestBothGenerationsAgree:
+    """Both generations produce the same Pose.
+
+    A 900-series shadow pose and a requested one describe the same
+    frame in different units. Converting in the library rather than in
+    each consumer is the point: five callers would write the same
+    formula five times, and one would get a sign wrong.
+    """
+
+    def test_shadow_converts_to_the_same_units(self) -> None:
+        """Millimetres and degrees become metres and radians."""
+        pose = rrtp.pose_from_shadow(
+            {"theta": 153, "point": {"x": -16, "y": 243}}
+        )
+
+        assert pose is not None
+        # Negative on purpose -- a flipped sign in a unit conversion
+        # survives a test built only from positive numbers.
+        assert pose.x == pytest.approx(-0.016)
+        assert pose.y == pytest.approx(0.243)
+        assert pose.theta == pytest.approx(math.radians(153))
+
+    def test_source_still_tells_them_apart(self) -> None:
+        """Unifying the units must not hide the cost difference:.
+
+        listening to a shadow is free, every requested pose is a round
+        trip.
+        """
+        shadow = rrtp.pose_from_shadow({"theta": 0, "point": {"x": 0, "y": 0}})
+        requested = rrtp.parse_response(DOCKED)
+
+        assert shadow is not None
+        assert requested is not None
+        assert shadow.source == "shadow"
+        assert requested.source == "request"
+
+    def test_a_malformed_shadow_pose_is_none(self) -> None:
+        """A pose without a point is not a pose."""
+        assert rrtp.pose_from_shadow({"theta": 0}) is None
+
+
+class TestThetaWrapIsNotSmoothed:
+    """@Thonno's rate run caught a turn in place crossing pi:.
+
+        -1.43 -> -0.53 -> 0.53 -> 1.33 -> 1.97 -> 2.40 -> 3.06 -> -2.63
+
+    The library reports what arrived. Normalising here would hide a
+    discontinuity that consumers computing heading deltas have to know
+    about -- otherwise a 30-degree turn reads as a 330-degree one.
+    """
+
+    def test_values_pass_through_unchanged(self) -> None:
+        """Both sides of the wrap survive intact."""
+        for theta in (3.06, -2.63):
+            reply = {
+                "ver": "1.0.0",
+                "data": [
+                    {"coords": [{"type": "current", "xyt": [0.0, 0.0, theta]}]}
+                ],
+            }
+            pose = rrtp.parse_response(reply)
+
+            assert pose is not None
+            assert pose.theta == theta
+
+
+class TestRequestMatching:
+    """reqId is the only correlation the protocol offers."""
+
+    @pytest.mark.asyncio
+    async def test_a_reply_resolves_its_own_request(self) -> None:
+        """The matching id delivers the answer."""
+        requests = rrtp.RrtpRequests()
+        req_id, future = requests.new_request()
+
+        assert requests.resolve(dict(DOCKED, reqId=req_id)) is True
+        assert (await future) is not None
+
+    @pytest.mark.asyncio
+    async def test_a_stranger_reply_resolves_nothing(self) -> None:
+        """Matched by id, never by arrival order.
+
+        Another client on the same broker, or an answer to a request
+        that already timed out, must not satisfy this one -- that is how
+        a caller quietly receives somebody else's position.
+        """
+        requests = rrtp.RrtpRequests()
+        _req_id, future = requests.new_request()
+
+        assert requests.resolve(dict(DOCKED, reqId="not-ours")) is False
+        assert not future.done()
+
+    @pytest.mark.asyncio
+    async def test_abandoning_leaves_nothing_behind(self) -> None:
+        """A caller that gave up leaves no trace."""
+        requests = rrtp.RrtpRequests()
+        req_id, _future = requests.new_request()
+        requests.abandon(req_id)
+
+        assert requests.in_flight == 0
+        assert requests.resolve(dict(DOCKED, reqId=req_id)) is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_all_fails_everything_outstanding(self) -> None:
+        """Disconnect fails every waiter."""
+        requests = rrtp.RrtpRequests()
+        _req_id, future = requests.new_request()
+        requests.cancel_all()
+        await asyncio.sleep(0)
+
+        assert future.cancelled()
+        assert requests.in_flight == 0
+
+
+class TestTheRequestBody:
+    """What goes out on ."""
+
+    def test_it_matches_what_the_app_sends(self) -> None:
+        """Three fields, no more."""
+        body = rrtp.build_request("abc")
+
+        assert body == {
+            "reqId": "abc",
+            "reqType": "current",
+            "conType": "local",
+        }
+
+    def test_only_current_is_offered(self) -> None:
+        """`historical`, `update` and `adjustment` are in the firmware's.
+
+        enum. lewis checks them and rejects them -- verified on an i7+,
+        all three silent while a nonsense type was also silent, so the
+        field is read and the silence means 'not implemented here'.
+
+        Offering them would invite callers to send requests no shipping
+        robot answers.
+        """
+        assert rrtp.REQUEST_TYPE_CURRENT == "current"
+        assert not hasattr(rrtp, "REQUEST_TYPE_HISTORICAL")

--- a/tests/test_rrtp_client.py
+++ b/tests/test_rrtp_client.py
@@ -689,10 +689,16 @@ class TestTwoWatchersDoNotDoublePoll:
     which is the exact thing one shared poller exists to prevent.
     """
 
-    def test_the_second_restart_is_a_no_op(self) -> None:
-        """Only the watcher that saw the stale task replaces it."""
+    @pytest.mark.asyncio
+    async def test_the_second_restart_is_a_no_op(self) -> None:
+        """Only the watcher that saw the stale task replaces it.
+
+        Async because `asyncio.Future()` needs a running loop -- outside
+        one, Python 3.14 raises rather than making a policy loop, and
+        this failed only there.
+        """
         client = _client()
-        stale = asyncio.Future()
+        stale = asyncio.get_running_loop().create_future()
         client._position_poller = stale  # type: ignore[assignment]
 
         client._restart_poller(stale, 5.0)  # type: ignore[arg-type]

--- a/tests/test_rrtp_client.py
+++ b/tests/test_rrtp_client.py
@@ -1,0 +1,326 @@
+"""The rrtp path through RoombaClient: routing, polling, and giving up.
+
+These drive `_handle_message` and the poller directly, the way
+test_message_handling.py does, so no broker is involved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from roombapy import roomba as roomba_module
+from roombapy import rrtp
+from roombapy.roomba import (
+    _DEFAULT_POSITION_INTERVAL,
+    _MIN_POSITION_INTERVAL,
+    RoombaClient,
+    TransportOptions,
+)
+
+from tests.conftest import ROOMBA_HOST, ROOMBA_PASSWORD, ROOMBA_USERNAME
+
+SHADOW = b'{"state":{"reported":{"batPct":42}}}'
+
+REPLY = (
+    b'{"reportType":"current","reqId":"%s","ver":"1.0.0",'
+    b'"data":[{"pmap_id":"tM_G","pmapv_id":"260901T",'
+    b'"coords":[{"type":"current","xyt":[0.31,-1.74,-1.59],'
+    b'"ts":1788290847}]}]}'
+)
+
+
+def monkey_grace(seconds: float) -> None:
+    """Shorten the shadow grace period for a test.
+
+    The poller waits before asking, so that a robot which publishes its
+    position is never polled. Three seconds is right in the field and
+    pointless in a test.
+    """
+    roomba_module._SHADOW_GRACE = seconds
+
+
+def _client(**options: object) -> RoombaClient:
+    return RoombaClient(
+        address=ROOMBA_HOST,
+        blid=ROOMBA_USERNAME,
+        password=ROOMBA_PASSWORD,
+        transport=TransportOptions(**options),  # type: ignore[arg-type]
+    )
+
+
+class TestAReplyIsNotState:
+    """The whole reason the branch sits before `_state.apply()`."""
+
+    def test_a_reply_never_reaches_master_state(self) -> None:
+        """`reportType` and `data` must not land beside `state`."""
+        client = _client()
+        client._handle_message("data", REPLY % b"nobody")
+
+        assert client.master_state == {}
+
+    def test_the_shadow_still_does(self) -> None:
+        """A negative control: routing one topic must not break the rest."""
+        client = _client()
+        client._handle_message("cmd", SHADOW)
+
+        assert client.master_state["state"]["reported"]["batPct"] == 42
+
+    def test_without_the_branch_it_would_land(self) -> None:
+        """Proves the branch is doing the work.
+
+        Applying the same payload through the state machine directly
+        puts `reportType` and `data` at the top level, next to `state` --
+        which is what every consumer reading master_state would see.
+        """
+        client = _client()
+        client._state.apply(
+            {"reportType": "current", "reqId": "x", "data": [{}]}
+        )
+
+        assert "reportType" in client.master_state
+
+
+class TestOnePollerForEveryWatcher:
+    """A robot has one local connection.
+
+    Two callers running their own loops would double the load without
+    either noticing, which is why the interval belongs to the library.
+    """
+
+    @pytest.mark.asyncio
+    async def test_two_watchers_share_one_poller(self) -> None:
+        """The second watcher must not start a second poller."""
+        client = _client()
+        sent: list[str] = []
+
+        async def _fake_publish(_topic: str, payload: str) -> None:
+            sent.append(_topic)
+            # Answer immediately so the poller keeps moving.
+            req_id = json.loads(payload)["reqId"]
+            client._handle_message("data", REPLY % req_id.encode())
+
+        client._publish = _fake_publish  # type: ignore[method-assign]
+
+        first = client.watch_position(interval=0.5)
+        second = client.watch_position(interval=0.5)
+        await anext(first)
+        await anext(second)
+
+        assert len(client._position_watchers) == 2
+        poller = client._position_poller
+        assert poller is not None
+
+        await first.aclose()
+        # Still one watcher left -- the poller must survive.
+        assert client._position_poller is poller
+
+        await second.aclose()
+        assert client._position_poller is None
+
+    @pytest.mark.asyncio
+    async def test_an_interval_below_the_floor_is_refused(self) -> None:
+        """Nobody has tested faster than 2 Hz on real hardware."""
+        client = _client()
+
+        with pytest.raises(ValueError, match="floor"):
+            await anext(client.watch_position(interval=0.05))
+
+
+class TestGivingUpOnASilentRobot:
+    """Silence means the generation does not implement the request.
+
+    Across 100 consecutive requests on a moving robot there was not one
+    miss, so a robot answers or it never does -- and a stream that kept
+    asking would poll a robot that cannot answer for a whole mission.
+    """
+
+    @pytest.mark.asyncio
+    async def test_three_timeouts_raise_rather_than_ending_quietly(
+        self,
+    ) -> None:
+        """An empty stream reads as 'mission over'; an exception does not."""
+        client = _client()
+
+        async def _silent_publish(_topic: str, _payload: str) -> None:
+            return  # nothing ever answers
+
+        client._publish = _silent_publish  # type: ignore[method-assign]
+
+        # The poller runs only while somebody is listening -- that is
+        # what stops it when the last watcher leaves.
+        queue: asyncio.Queue[rrtp.RobotPosition] = asyncio.Queue(maxsize=4)
+        client._position_watchers.add(queue)
+
+        monkey_grace(0.01)
+        with pytest.raises(rrtp.RrtpUnsupportedError):
+            await client._run_position_poller(interval=0.01, timeout=0.05)
+
+    @pytest.mark.asyncio
+    async def test_one_miss_does_not(self) -> None:
+        """A single failure can be a dropped connection, not a verdict."""
+        client = _client()
+        calls = {"n": 0}
+
+        async def _flaky_publish(_topic: str, payload: str) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return  # first one goes missing
+            req_id = json.loads(payload)["reqId"]
+            client._handle_message("data", REPLY % req_id.encode())
+
+        client._publish = _flaky_publish  # type: ignore[method-assign]
+
+        queue: asyncio.Queue[rrtp.RobotPosition] = asyncio.Queue(maxsize=4)
+        client._position_watchers.add(queue)
+        # The poller listens for a shadow pose before asking; shortened
+        # here so the test does not wait out the real grace period.
+        monkey_grace(0.01)
+        task = asyncio.ensure_future(
+            client._run_position_poller(interval=0.01, timeout=0.05)
+        )
+        pose = await asyncio.wait_for(queue.get(), timeout=5.0)
+        client._position_watchers.discard(queue)
+        task.cancel()
+
+        assert pose.x == 0.31
+
+
+class TestNoFixIsSkippedNotYielded:
+    """A stream of positions should carry positions.
+
+    A Braava jet m6 answered every request with `type: "unknown"` and no
+    coordinates for a whole mission; yielding None for each would make
+    every consumer filter them out.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_no_fix_reply_produces_nothing(self) -> None:
+        """The poller waits for a real position rather than passing None."""
+        client = _client()
+        no_fix = (
+            b'{"reportType":"current","reqId":"%s","ver":"1.0.0",'
+            b'"data":[{"pmap_id":"jUd","coords":[{"type":"unknown"}]}]}'
+        )
+
+        async def _no_fix_publish(_topic: str, payload: str) -> None:
+            req_id = json.loads(payload)["reqId"]
+            client._handle_message("data", no_fix % req_id.encode())
+
+        client._publish = _no_fix_publish  # type: ignore[method-assign]
+
+        queue: asyncio.Queue[rrtp.RobotPosition] = asyncio.Queue(maxsize=4)
+        client._position_watchers.add(queue)
+        monkey_grace(0.01)
+        task = asyncio.ensure_future(
+            client._run_position_poller(interval=0.01, timeout=0.5)
+        )
+        await asyncio.sleep(0.2)
+        task.cancel()
+        client._position_watchers.discard(queue)
+
+        assert queue.empty()
+
+
+class TestTheDefaultIsNotTheTestedCeiling:
+    """2 Hz was a stress test, not a recommendation.
+
+    @Thonno chose 0.5 s to see whether the robot would hold up and
+    whether a rate limit existed -- and said so before anyone built on
+    the number. The default is half that: ~4,600 requests over a
+    77-minute mission instead of ~9,200, at a spacing still comparable
+    to what a 900-series publishes for free.
+    """
+
+    def test_the_default_is_slower_than_the_floor_allows(self) -> None:
+        """The floor is what was verified; the default is deliberate."""
+        assert _DEFAULT_POSITION_INTERVAL > _MIN_POSITION_INTERVAL
+
+    @pytest.mark.asyncio
+    async def test_the_tested_rate_is_still_available(self) -> None:
+        """A caller who has decided the traffic is worth it can ask.
+
+        The floor is the verified rate, so it must not be refused --
+        only anything faster than it.
+        """
+        client = _client()
+
+        with pytest.raises(ValueError, match="floor"):
+            await anext(client.watch_position(interval=0.4))
+
+
+class TestOneStreamForBothGenerations:
+    """Both paths reach the same stream.
+
+    The seam that was missing: two conversions, both correct, and no
+    path connecting them.
+
+    A consumer should not have to know which generation it has. That is
+    what `RobotPosition` carrying `source` is for -- and it only works
+    if both paths reach the same stream.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_shadow_pose_reaches_the_position_stream(self) -> None:
+        """A 900-series publishes; nobody asks it anything."""
+        client = _client()
+        queue: asyncio.Queue[rrtp.RobotPosition] = asyncio.Queue(maxsize=4)
+        client._position_watchers.add(queue)
+
+        client._handle_message(
+            "cmd",
+            b'{"state":{"reported":{"pose":'
+            b'{"theta":153,"point":{"x":-16,"y":243}}}}}',
+        )
+
+        pose = queue.get_nowait()
+        assert pose.source == "shadow"
+        assert pose.x == pytest.approx(-0.016)
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_fed_when_nobody_listens(self) -> None:
+        """A shadow pose with no watchers costs nothing."""
+        client = _client()
+        client._handle_message(
+            "cmd",
+            b'{"state":{"reported":{"pose":'
+            b'{"theta":0,"point":{"x":0,"y":0}}}}}',
+        )
+
+        assert not client._position_watchers
+
+    @pytest.mark.asyncio
+    async def test_a_publishing_robot_is_never_polled(self) -> None:
+        """Polling a 900-series would add traffic for free data.
+
+        And it would then raise RrtpUnsupportedError, killing a stream
+        that was working perfectly well.
+        """
+        client = _client()
+        asked: list[str] = []
+
+        async def _count_publish(_topic: str, _payload: str) -> None:
+            asked.append(_topic)
+
+        client._publish = _count_publish  # type: ignore[method-assign]
+        # Through _handle_message, not _state.apply: that is the path
+        # that notices a shadow pose, and going round it would test a
+        # route the robot never takes.
+        client._handle_message(
+            "cmd",
+            b'{"state":{"reported":{"pose":'
+            b'{"theta":0,"point":{"x":0,"y":0}}}}}',
+        )
+
+        queue: asyncio.Queue[rrtp.RobotPosition] = asyncio.Queue(maxsize=4)
+        client._position_watchers.add(queue)
+        monkey_grace(0.01)
+        task = asyncio.ensure_future(
+            client._run_position_poller(interval=0.01, timeout=0.05)
+        )
+        await asyncio.sleep(0.2)
+        task.cancel()
+        client._position_watchers.discard(queue)
+
+        assert asked == []

--- a/tests/test_rrtp_client.py
+++ b/tests/test_rrtp_client.py
@@ -151,11 +151,11 @@ class TestGivingUpOnASilentRobot:
         # The poller runs only while somebody is listening -- that is
         # what stops it when the last watcher leaves.
         queue: asyncio.Queue[rrtp.RobotPosition] = asyncio.Queue(maxsize=4)
-        client._position_watchers.add(queue)
+        client._position_watchers[queue] = 0.5
 
         monkey_grace(0.01)
         with pytest.raises(rrtp.RrtpUnsupportedError):
-            await client._run_position_poller(interval=0.01, timeout=0.05)
+            await client._run_position_poller(timeout=0.05)
 
     @pytest.mark.asyncio
     async def test_one_miss_does_not(self) -> None:
@@ -173,15 +173,13 @@ class TestGivingUpOnASilentRobot:
         client._publish = _flaky_publish  # type: ignore[method-assign]
 
         queue: asyncio.Queue[rrtp.RobotPosition] = asyncio.Queue(maxsize=4)
-        client._position_watchers.add(queue)
+        client._position_watchers[queue] = 0.5
         # The poller listens for a shadow pose before asking; shortened
         # here so the test does not wait out the real grace period.
         monkey_grace(0.01)
-        task = asyncio.ensure_future(
-            client._run_position_poller(interval=0.01, timeout=0.05)
-        )
+        task = asyncio.ensure_future(client._run_position_poller(timeout=0.05))
         pose = await asyncio.wait_for(queue.get(), timeout=5.0)
-        client._position_watchers.discard(queue)
+        client._position_watchers.pop(queue, None)
         task.cancel()
 
         assert pose.x == 0.31
@@ -211,14 +209,12 @@ class TestNoFixIsSkippedNotYielded:
         client._publish = _no_fix_publish  # type: ignore[method-assign]
 
         queue: asyncio.Queue[rrtp.RobotPosition] = asyncio.Queue(maxsize=4)
-        client._position_watchers.add(queue)
+        client._position_watchers[queue] = 0.5
         monkey_grace(0.01)
-        task = asyncio.ensure_future(
-            client._run_position_poller(interval=0.01, timeout=0.5)
-        )
+        task = asyncio.ensure_future(client._run_position_poller(timeout=0.5))
         await asyncio.sleep(0.2)
         task.cancel()
-        client._position_watchers.discard(queue)
+        client._position_watchers.pop(queue, None)
 
         assert queue.empty()
 
@@ -266,7 +262,7 @@ class TestOneStreamForBothGenerations:
         """A 900-series publishes; nobody asks it anything."""
         client = _client()
         queue: asyncio.Queue[rrtp.RobotPosition] = asyncio.Queue(maxsize=4)
-        client._position_watchers.add(queue)
+        client._position_watchers[queue] = 0.5
 
         client._handle_message(
             "cmd",
@@ -314,13 +310,437 @@ class TestOneStreamForBothGenerations:
         )
 
         queue: asyncio.Queue[rrtp.RobotPosition] = asyncio.Queue(maxsize=4)
-        client._position_watchers.add(queue)
+        client._position_watchers[queue] = 0.5
         monkey_grace(0.01)
-        task = asyncio.ensure_future(
-            client._run_position_poller(interval=0.01, timeout=0.05)
-        )
+        task = asyncio.ensure_future(client._run_position_poller(timeout=0.05))
         await asyncio.sleep(0.2)
         task.cancel()
-        client._position_watchers.discard(queue)
+        client._position_watchers.pop(queue, None)
 
         assert asked == []
+
+
+class TestTheConsumerFindsOut:
+    """Raising in the poller is pointless if nobody hears it.
+
+    Found by review, not by these tests: `watch_position` awaited the
+    queue alone, so when the poller raised RrtpUnsupportedError the
+    exception died inside the task and the consumer waited forever for a
+    position that would never arrive.
+
+    The error exists so an unsupported robot is visible rather than
+    looking like a finished mission. A consumer that hangs instead is
+    worse than one that gets an empty stream.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_unsupported_robot_raises_at_the_consumer(self) -> None:
+        """The exception has to cross from the poller to the caller."""
+        client = _client()
+
+        async def _silent(_topic: str, _payload: str) -> None:
+            return
+
+        client._publish = _silent  # type: ignore[method-assign]
+        monkey_grace(0.01)
+
+        with pytest.raises(rrtp.RrtpUnsupportedError):
+            # The floor applies -- 0.5 is the fastest a caller may
+            # ask for, and three timeouts at 0.02 s settle it quickly.
+            async for _pose in client.watch_position(
+                interval=0.5, timeout=0.02
+            ):
+                pass  # pragma: no cover - never reached
+
+    @pytest.mark.asyncio
+    async def test_a_failing_publish_does_not_leak_a_request(self) -> None:
+        """A request whose publish raises must not sit in _pending.
+
+        Also from review. A poller retrying once a second against a
+        disconnected client would otherwise accumulate futures for the
+        lifetime of the client.
+        """
+        client = _client()
+
+        async def _boom(_topic: str, _payload: str) -> None:
+            msg = "not connected"
+            raise RuntimeError(msg)
+
+        client._publish = _boom  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError):
+            await client.get_position(timeout=0.5)
+
+        assert client._rrtp.in_flight == 0
+
+
+class TestDisconnectDoesNotStrandAnyone:
+    """`cancel_all` existed and was never called.
+
+    Written for the disconnect case and then not wired to it — a caller
+    awaiting a position when the connection dropped would have sat on a
+    future that nothing could resolve, because the reply was going to
+    arrive on a socket that no longer exists.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_pending_request_is_cancelled(self) -> None:
+        """The waiter finds out instead of waiting forever."""
+        client = _client()
+        _req_id, future = client._rrtp.new_request()
+
+        client._rrtp.cancel_all()
+        await asyncio.sleep(0)
+
+        assert future.cancelled()
+        assert client._rrtp.in_flight == 0
+
+
+class TestTheFastestWatcherWins:
+    """One poller serves everyone, so its rate has to satisfy everyone.
+
+    A second caller asking for a shorter interval was silently given the
+    first caller's slower one — a sparser trail than it asked for, with
+    nothing to explain why.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_faster_watcher_restarts_the_poller(self) -> None:
+        """The shortest requested interval is the one that runs."""
+        client = _client()
+
+        async def _silent(_topic: str, _payload: str) -> None:
+            return
+
+        client._publish = _silent  # type: ignore[method-assign]
+        monkey_grace(30.0)  # keep the poller in its listening phase
+
+        slow = client.watch_position(interval=2.0)
+        task = asyncio.ensure_future(anext(slow))
+        await asyncio.sleep(0)
+        assert client._position_interval == 2.0
+
+        fast = client.watch_position(interval=0.5)
+        task2 = asyncio.ensure_future(anext(fast))
+        await asyncio.sleep(0)
+
+        assert client._position_interval == 0.5
+
+        # Let the cancellations land before closing the generators --
+        # aclose() on a generator still mid-await raises.
+        task.cancel()
+        task2.cancel()
+        await asyncio.sleep(0)
+        await asyncio.gather(task, task2, return_exceptions=True)
+        await slow.aclose()
+        await fast.aclose()
+        # The generators are gone, but the poller they started is not
+        # awaited by anything -- pytest reports it as a stray task.
+
+    @pytest.mark.asyncio
+    async def test_the_rate_resets_when_everyone_leaves(self) -> None:
+        """Otherwise the next stream inherits a rate nobody asked for."""
+        client = _client()
+
+        async def _silent(_topic: str, _payload: str) -> None:
+            return
+
+        client._publish = _silent  # type: ignore[method-assign]
+        monkey_grace(30.0)
+
+        stream = client.watch_position(interval=0.5)
+        task = asyncio.ensure_future(anext(stream))
+        await asyncio.sleep(0)
+        task.cancel()
+        await asyncio.sleep(0)
+        await asyncio.gather(task, return_exceptions=True)
+        await stream.aclose()
+
+        assert client._position_interval == float("inf")
+
+    @pytest.mark.asyncio
+    async def test_a_fast_watcher_leaving_slows_the_poller(self) -> None:
+        """The rate drops back when the fastest watcher leaves.
+
+        Otherwise one caller's 0.5 s is paid for by everyone else after
+        it has gone.
+        """
+        client = _client()
+
+        async def _silent(_topic: str, _payload: str) -> None:
+            return
+
+        client._publish = _silent  # type: ignore[method-assign]
+        monkey_grace(30.0)
+
+        slow = client.watch_position(interval=2.0)
+        fast = client.watch_position(interval=0.5)
+        t1 = asyncio.ensure_future(anext(slow))
+        t2 = asyncio.ensure_future(anext(fast))
+        await asyncio.sleep(0)
+        assert client._position_interval == 0.5
+
+        t2.cancel()
+        await asyncio.sleep(0)
+        await asyncio.gather(t2, return_exceptions=True)
+        await fast.aclose()
+
+        assert client._position_interval == 2.0
+
+        t1.cancel()
+        await asyncio.sleep(0)
+        await asyncio.gather(t1, return_exceptions=True)
+        await slow.aclose()
+
+
+class TestAskingTwiceCostsNothing:
+    """A robot that cannot answer should be asked once, not per stream.
+
+    Without this, a dashboard opening and closing a map view spends
+    three requests and a grace period every time, against a robot
+    already known to be silent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_second_stream_fails_immediately(self) -> None:
+        """No requests, no grace period, same exception."""
+        client = _client()
+        client._position_unsupported = True
+
+        with pytest.raises(rrtp.RrtpUnsupportedError, match="earlier"):
+            await anext(client.watch_position())
+
+    def test_disconnect_forgets_it(self) -> None:
+        """The verdict does not outlive its connection.
+
+        A firmware update that adds the capability brings a reconnect
+        with it.
+        """
+        client = _client()
+        client._position_unsupported = True
+
+        client._rrtp.cancel_all()
+        client._position_unsupported = False  # what disconnect does
+
+        assert not client._position_unsupported
+
+
+class TestSwitchingToTheShadowMidStream:
+    """The stream survives learning that the robot publishes.
+
+    A stream opened before the first shadow message must not die when
+    that message arrives.
+
+    The poller starts, a shadow pose arrives, `_handle_message` cancels
+    it -- and the consumer was then handed CancelledError for a stream
+    that had just started working properly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_poller_does_not_end_the_stream(self) -> None:
+        """The shadow takes over; the consumer keeps receiving."""
+        client = _client()
+
+        async def _silent(_topic: str, _payload: str) -> None:
+            return
+
+        client._publish = _silent  # type: ignore[method-assign]
+        monkey_grace(30.0)  # keep the poller in its listening phase
+
+        stream = client.watch_position()
+        first = asyncio.ensure_future(anext(stream))
+        await asyncio.sleep(0)
+
+        # THE POLLER DIES FIRST, THEN THE POSE ARRIVES. That ordering is
+        # the one that matters: the consumer wakes on the cancelled
+        # poller with an empty queue, and has to keep waiting rather
+        # than raise. Cancelling and feeding in one step would leave the
+        # queue non-empty and never reach that branch.
+        client._shadow_publishes_pose = True
+        assert client._position_poller is not None
+        client._position_poller.cancel()
+        await asyncio.sleep(0.05)
+
+        client._handle_message(
+            "cmd",
+            b'{"state":{"reported":{"pose":'
+            b'{"theta":153,"point":{"x":-16,"y":243}}}}}',
+        )
+
+        pose = await asyncio.wait_for(first, timeout=2.0)
+        assert pose.source == "shadow"
+        assert client._shadow_publishes_pose
+
+        await stream.aclose()
+
+
+class TestASingleCallReadsTheShadowToo:
+    """One call reads the shadow instead of asking.
+
+    `watch_position()` listens before polling; a single call has no
+    such window, so it reads what has already arrived.
+
+    Without this a 900-series user gets a TimeoutError for a position
+    that is sitting in `master_state`.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_publishing_robot_is_not_asked(self) -> None:
+        """No request goes out when the shadow already has a pose."""
+        client = _client()
+        asked: list[str] = []
+
+        async def _count(_topic: str, _payload: str) -> None:
+            asked.append(_topic)
+
+        client._publish = _count  # type: ignore[method-assign]
+        client._handle_message(
+            "cmd",
+            b'{"state":{"reported":{"pose":'
+            b'{"theta":153,"point":{"x":-16,"y":243}}}}}',
+        )
+
+        pose = await client.get_position(timeout=0.5)
+
+        assert pose is not None
+        assert pose.source == "shadow"
+        assert asked == []
+
+    @pytest.mark.asyncio
+    async def test_a_silent_robot_is_still_asked(self) -> None:
+        """A negative control: no shadow pose means the request goes."""
+        client = _client()
+        asked: list[str] = []
+
+        async def _count(_topic: str, _payload: str) -> None:
+            asked.append(_topic)
+
+        client._publish = _count  # type: ignore[method-assign]
+
+        with pytest.raises(TimeoutError):
+            await client.get_position(timeout=0.05)
+
+        assert asked == ["req"]
+
+
+class TestDisconnectForgetsBothVerdicts:
+    """Both flags describe the robot as seen over one session."""
+
+    def test_neither_survives(self) -> None:
+        """A firmware update that changes either brings a reconnect."""
+        client = _client()
+        client._position_unsupported = True
+        client._shadow_publishes_pose = True
+
+        client._forget_position_capabilities()
+
+        assert not client._position_unsupported
+        assert not client._shadow_publishes_pose
+
+
+class TestAReconnectDoesNotEndTheStream:
+    """The client reconnects on its own; the stream should come back.
+
+    `_supervise` tears the connection down and rebuilds it, cancelling
+    the poller on the way through. A stream that just returned there
+    would leave the consumer with a finished iterator and no
+    explanation — indistinguishable from a completed mission, while the
+    client carried on working perfectly well.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_poller_is_restarted(self) -> None:
+        """A cancelled poller on a live client means restart, not stop."""
+        client = _client()
+
+        async def _silent(_topic: str, _payload: str) -> None:
+            return
+
+        client._publish = _silent  # type: ignore[method-assign]
+        client._connected = True
+        monkey_grace(30.0)
+
+        stream = client.watch_position()
+        pending = asyncio.ensure_future(anext(stream))
+        await asyncio.sleep(0)
+
+        first_poller = client._position_poller
+        assert first_poller is not None
+
+        # What a reconnect does on the way past.
+        client._forget_position_capabilities()
+        first_poller.cancel()
+        await asyncio.sleep(0.05)
+
+        assert client._position_poller is not first_poller
+        assert not pending.done()
+
+        pending.cancel()
+        await asyncio.sleep(0)
+        await asyncio.gather(pending, return_exceptions=True)
+        await stream.aclose()
+
+
+class TestTwoWatchersDoNotDoublePoll:
+    """Both wake on the same dead poller and both try to replace it.
+
+    The second assignment overwrites the first, whose task keeps running
+    unreferenced — two pollers asking the same robot twice as often,
+    which is the exact thing one shared poller exists to prevent.
+    """
+
+    def test_the_second_restart_is_a_no_op(self) -> None:
+        """Only the watcher that saw the stale task replaces it."""
+        client = _client()
+        stale = asyncio.Future()
+        client._position_poller = stale  # type: ignore[assignment]
+
+        client._restart_poller(stale, 5.0)  # type: ignore[arg-type]
+        first = client._position_poller
+        assert first is not stale
+
+        # Second watcher, still holding the task it saw.
+        client._restart_poller(stale, 5.0)  # type: ignore[arg-type]
+
+        assert client._position_poller is first
+
+        if first is not None:
+            first.cancel()
+
+
+class TestClosingAStreamLeavesNothingRunning:
+    """A closed stream leaves no task running.
+
+    `cancel()` only requests it; the task stays pending until the loop
+    gets round to it.
+
+    A caller that closes a stream and tears down its event loop would
+    otherwise leave a task behind — and four tests here had to clean it
+    up by hand, which was the library asking its callers to finish a job
+    it started.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_poller_is_finished_when_aclose_returns(self) -> None:
+        """Not merely cancelled: actually done."""
+        client = _client()
+
+        async def _silent(_topic: str, _payload: str) -> None:
+            return
+
+        client._publish = _silent  # type: ignore[method-assign]
+        monkey_grace(30.0)
+
+        stream = client.watch_position()
+        pending = asyncio.ensure_future(anext(stream))
+        await asyncio.sleep(0)
+        poller = client._position_poller
+        assert poller is not None
+
+        pending.cancel()
+        await asyncio.sleep(0)
+        await asyncio.gather(pending, return_exceptions=True)
+        await stream.aclose()
+
+        assert poller.done()
+        assert client._position_poller is None


### PR DESCRIPTION
<html><head></head><body><h1>Live position for robots that stopped publishing one</h1>
<h2>The problem</h2>
<p>Since roughly 2021, newer Roombas stopped putting <code>pose</code> in their local
shadow. This library notes it in passing, dorita980 has a line about it
in its README, and there is an issue on that tracker — <em>"Roomba S9+
after v3.20.7 no 'pose' data available"</em> — open since November 2021,
labelled <em>Information</em>, never diagnosed.</p>
<p>The assumption everywhere has been that the capability was removed.</p>
<p><strong>It was not. It moved from push to pull.</strong> Those robots answer a
position request; nobody was asking.</p>
<h2>How we found it</h2>
<p>Reverse engineering plus field testing, in that order, with several
wrong turns worth mentioning because they shaped the result.</p>
<p><strong>The app.</strong> <code>com.irobot.home</code> 7.18.0 has a
<code>GetRobotPositionLocalSecureSocketSerializer</code> that builds
<code>{"reqId", "reqType", "conType"}</code>. Where it publishes was not resolved
initially — the class name suggested a socket, and the internal event
bus names <code>local/rrtp/request</code> and <code>cloud/rrtp/request</code> looked like
topics.</p>
<p><strong>They are not.</strong> Four field runs against those addresses came back
silent, on four robots. The <code>local/</code> and <code>cloud/</code> prefixes mark where a
message originated on the robot's internal bus, not where a client
sends it. Externally the prefix is dropped, exactly as <code>local/cmd</code> is
just <code>cmd</code>.</p>
<p><strong>The topic is <code>req</code></strong>, decoded from the app's own initialiser:</p>
<pre><code>init @0x007657e8
  mov  w8, #0x6572          'r','e'
  movk w8, #0x71, lsl #16   -&gt; 0x00716572 = 'r','e','q','\0'
  strb w21, [x1]            w21 = 6 = 3&lt;&lt;1, so length 3
</code></pre>
<p>Confirmed independently on the robot side, in two firmware modules:</p>
<pre><code>connectivity_manager (src/redirect.c)   delta cmd wifictl wifilog req
local_manager (src/mqtt_publish.c)      wifictl schedule delta ota_update req
</code></pre>
<p><strong>The decoding method was cross-checked before being trusted.</strong> The
same reconstruction applied to the sibling constants yields <code>cmd</code>,
<code>delta</code> and <code>wifictl</code> — names already known correct from this library.
That check is the difference between this result and the four addresses
that preceded it.</p>
<p><strong>The response topic is <code>data</code></strong>, and that one came only from the wire.
It is not derivable from the request topic and does not appear in any
decompiled string we found.</p>
<h2>What field testing established</h2>
<p>Four robots, three firmware families, run by three testers.</p>

Robot | Firmware | Result
-- | -- | --
i7+ | lewis | coordinates, repeatedly
S9+ (×2) | lewis | coordinates, mid-mission
Braava jet m6 | sanmarino | answers, type: "unknown", no fix
i3 | daredevil | not run — robot unavailable


<p><strong>Units and frame.</strong> Metres and radians, origin at the dock, x-axis
along the direction the robot faces when docked. Established by a
docked reading of <code>[-0.01, 0.0, 0.0]</code> — the −0.01 being the useful
part, since a hardcoded docked value would read exactly zero.</p>
<p><strong>Rate.</strong> 100 of 100 requests answered at 2 Hz on a robot mid-clean,
latencies 0.24–0.78 s, no missed responses. Eight consecutive identical
poses during a pause in that run confirm the value is computed per
request rather than cached — a stale or interpolated value would have
drifted.</p>
<p><strong>No fix is a real state.</strong> The Braava answered every request with
<code>type: "unknown"</code> and no <code>xyt</code> for an entire mission, while a vacuum on
the same account returned coordinates. Not an error; the robot does not
know where it is.</p>
<p><strong><code>theta</code> wraps at π.</strong> A turn in place went <code>3.06 → -2.63</code> in one
capture. Anything computing heading deltas has to handle it.</p>
<p><strong>Only <code>current</code> is implemented.</strong> <code>historical</code>, <code>update</code> and
<code>adjustment</code> are registered in the firmware's enum and explicitly
rejected. Verified on hardware: all three silent, alongside a nonsense
<code>reqType</code> that was also silent — so the field <em>is</em> read, and the
silence means "not implemented here" rather than "not looked at".
Without that control the result would have been ambiguous.</p>
<h2>What this PR does</h2>
<p><strong><code>roombapy/rrtp.py</code></strong> (new) — the protocol: request body, response
parsing, <code>reqId</code> correlation, and the shadow-pose conversion.</p>
<p><strong><code>roombapy/roomba.py</code></strong> — four changes:</p>
<ol>
<li>A branch in <code>_handle_message</code> routing <code>data</code> replies to the request
tracker <strong>before</strong> <code>_state.apply()</code>. The reply carries <code>reportType</code>,
<code>reqId</code> and <code>data</code> at the top level; <code>dict_merge</code> would file them
beside <code>state</code>, where every consumer reading <code>master_state</code> would
see them.</li>
<li>Shadow poses feed the same stream. A 900-series publishes rather
than answers, and a consumer should not have to know which
generation it has.</li>
<li><code>get_position()</code> and <code>watch_position()</code>.</li>
<li>One poller for however many watchers, on the <code>_watchers</code> pattern.</li>
</ol>
<p><strong><code>roombapy/__init__.py</code></strong> — exports <code>RobotPosition</code> and
<code>RrtpUnsupportedError</code>.</p>
<p><strong><code>README.md</code></strong> — a section on the new methods.</p>
<p><strong><code>roombapy/state.py</code> is untouched.</strong> The state machine and
<code>dict_merge</code> are the field-proven part; the branch sits in front of
them rather than inside.</p>
<h2>Design decisions worth flagging</h2>
<p><strong><code>RobotPosition</code>, not <code>Pose</code>.</strong> <code>types.Pose</code> already exists as the raw
shadow shape — a TypedDict of integer millimetres and degrees. This is
the interpreted form: floats, metres and radians, plus a <code>source</code>
field. Two names because they are two things; collapsing them would
hide a unit change behind a shared type.</p>
<p><strong>One stream, both generations.</strong> <code>watch_position()</code> reads the shadow
where it can and polls where it must. <code>source</code> says which, because the
cost differs — listening is free, every requested pose is a round trip.</p>
<p><strong>Listen before asking.</strong> The poller waits a few seconds for a shadow
pose before sending anything. A robot that publishes is never polled,
and the decision is made on what <em>arrives</em> rather than on a capability
flag.</p>
<p><strong>Nothing is gated on <code>cap.pose</code>.</strong> Neither the firmware nor the app
ever compares that value; lewis hard-codes it to 2. Across seven robots
it correlates perfectly with whether a pose is published — and that is
a correlation with model generation, not a cause. Support is
established by asking and handling silence.</p>
<p><strong>Default 1 Hz, floor 0.5 s.</strong> 2 Hz is the verified rate, but the
tester who measured it said plainly that it was a stress test rather
than a recommendation. A 77-minute mission at 2 Hz is ~9,200 requests
against ~4,600 at 1 Hz, and at 1 Hz the spacing is still ~125 mm —
comparable to the 132 mm a 900-series publishes for free. The default
should not be the hardest thing the robot survived.</p>
<p><strong><code>RrtpUnsupportedError</code> after three silent requests</strong>, rather than an
empty stream. Older generations do not implement this, and a stream
that quietly ends looks like a finished mission instead of an
unsupported robot. Three rather than one because a single miss can be a
dropped connection; across 100 consecutive requests there was not one.</p>
<h2>Testing</h2>
<p>27 new tests. Every payload is a real capture rather than an invented
one, including the no-fix reply and the π wrap.</p>
<p>The one worth pointing at: a negative control proving the routing
branch does something. Applying the same payload through the state
machine directly puts <code>reportType</code> at the top level of <code>master_state</code> —
without that assertion the routing test would pass whether or not the
branch existed.</p>
<p><code>ruff check</code>, <code>ruff format --check</code>, <code>codespell</code> and <code>mypy --strict</code>
all clean (the twelve <code>cli.py</code> findings predate this branch).</p>
<h2>What has not been done</h2>
<p><strong>This code has never run against a real robot.</strong> It is built from
captures and tested against reconstructed payloads. The protocol is
confirmed; this implementation of it is not. Worth a field run before
merging, and I can arrange one — the testers who produced the captures
have offered.</p>
<p>The full protocol specification, with addresses and the disassembly
behind each claim, is available if useful.</p></body></html>