### PR TITLE
fix(rrtp): accept the bare coords reply shape

### DIFF
--- a/roombapy/rrtp.py
+++ b/roombapy/rrtp.py
@@ -167,9 +167,7 @@ def _xyt_and_ts(entry: dict[str, Any]) -> tuple[Any, Any] | None:
     # anythings would satisfy a length test, and coercing the wrong
     # thing into a position is worse than reporting no fix.
     numeric = (int, float)
-    if all(
-        isinstance(v, numeric) and not isinstance(v, bool) for v in coords
-    ):
+    if all(isinstance(v, numeric) and not isinstance(v, bool) for v in coords):
         return coords, entry.get("ts")
 
     return None

--- a/roombapy/rrtp.py
+++ b/roombapy/rrtp.py
@@ -118,6 +118,63 @@ def _first_dict(value: Any) -> dict[str, Any] | None:
     return first if isinstance(first, dict) else None
 
 
+def _xyt_and_ts(entry: dict[str, Any]) -> tuple[Any, Any] | None:
+    """Return the coordinate triple and timestamp from one entry.
+
+    Handles whichever of the two reply shapes the robot used.
+
+    THERE ARE TWO, AND THE SECOND WAS UNKNOWN UNTIL A FIELD RUN FOUND
+    IT. Same `reportType`, same `ver: "1.0.0"`, same robot, minutes
+    apart:
+
+        coords: [{"type": "current", "xyt": [x, y, t], "ts": 123}]
+        coords: [x, y, t]        with "ts" one level up, on the entry
+
+    The second arrived from an i7+ on lewis 22.52.10 that had just
+    finished a mission and was sitting in its dock while the base
+    emptied (@Thonno, cloud path). It also omits `pmapv_id`, which the
+    object form carries.
+
+    WHAT IT COST BEFORE THIS EXISTED: the bare form was dropped
+    silently. `_first_dict(coords)` found a float where it wanted a
+    dict, returned None, and the caller reported "no fix" -- for a reply
+    that carried a real position. That window matters more than its
+    rarity suggests: it is precisely "localised, but no mission
+    running", which is where a robot sits at the end of a run. A live
+    map would have thrown away the one reading that says where the
+    cleaning ended.
+
+    Both shapes are accepted and neither is guessed at. A third shape
+    returns None rather than being coerced into one of these.
+    """
+    coords = entry.get("coords")
+    if not isinstance(coords, list) or not coords:
+        return None
+
+    first = coords[0]
+
+    # The documented object form.
+    if isinstance(first, dict):
+        # `type: "unknown"` omits `xyt` entirely -- a robot that answered
+        # and has no fix. Handled by the length check in the caller, not
+        # here, so that "no coordinates" and "malformed coordinates"
+        # stay one decision in one place.
+        return first.get("xyt"), first.get("ts")
+
+    # The bare form: coords IS the triple, and `ts` belongs to the entry.
+    #
+    # Checked by type rather than just by shape. A list of three
+    # anythings would satisfy a length test, and coercing the wrong
+    # thing into a position is worse than reporting no fix.
+    numeric = (int, float)
+    if all(
+        isinstance(v, numeric) and not isinstance(v, bool) for v in coords
+    ):
+        return coords, entry.get("ts")
+
+    return None
+
+
 def _parse_v1(decoded: dict[str, Any]) -> RobotPosition | None:
     """Parse a `ver: 1.0.0` reply.
 
@@ -129,11 +186,11 @@ def _parse_v1(decoded: dict[str, Any]) -> RobotPosition | None:
     first = _first_dict(decoded.get("data"))
     if first is None:
         return None
-    coord = _first_dict(first.get("coords"))
-    if coord is None:
+    found = _xyt_and_ts(first)
+    if found is None:
         return None
+    xyt, raw_ts = found
 
-    xyt = coord.get("xyt")
     # LENGTH-CHECKED, not just truthy. `type: "unknown"` omits the key
     # entirely, but a short or malformed list must not unpack.
     if not isinstance(xyt, (list, tuple)) or len(xyt) != 3:
@@ -141,7 +198,7 @@ def _parse_v1(decoded: dict[str, Any]) -> RobotPosition | None:
 
     try:
         x, y, theta = (float(v) for v in xyt)
-        ts = int(coord.get("ts", 0))
+        ts = int(raw_ts or 0)
     except (TypeError, ValueError):
         _LOGGER.debug("rrtp: unparsable coordinates %r", xyt)
         return None

--- a/roombapy/rrtp.py
+++ b/roombapy/rrtp.py
@@ -159,7 +159,12 @@ def _xyt_and_ts(entry: dict[str, Any]) -> tuple[Any, Any] | None:
         # and has no fix. Handled by the length check in the caller, not
         # here, so that "no coordinates" and "malformed coordinates"
         # stay one decision in one place.
-        return first.get("xyt"), first.get("ts")
+        #
+        # `get("ts", 0)` DEFAULTS ONLY ON A MISSING KEY, which is what
+        # the caller needs to stay strict. An explicit null or empty
+        # string must reach `int()` and raise there, exactly as before
+        # this function existed.
+        return first.get("xyt"), first.get("ts", 0)
 
     # The bare form: coords IS the triple, and `ts` belongs to the entry.
     #
@@ -168,7 +173,7 @@ def _xyt_and_ts(entry: dict[str, Any]) -> tuple[Any, Any] | None:
     # thing into a position is worse than reporting no fix.
     numeric = (int, float)
     if all(isinstance(v, numeric) and not isinstance(v, bool) for v in coords):
-        return coords, entry.get("ts")
+        return coords, entry.get("ts", 0)
 
     return None
 
@@ -196,7 +201,14 @@ def _parse_v1(decoded: dict[str, Any]) -> RobotPosition | None:
 
     try:
         x, y, theta = (float(v) for v in xyt)
-        ts = int(raw_ts or 0)
+        # `int(raw_ts)`, NOT `int(raw_ts or 0)`. The `or 0` form looks
+        # harmless and quietly loosened this: an explicit `"ts": null`
+        # or `"ts": ""` used to raise here and reject the whole reply,
+        # and would instead have become a position stamped at the epoch.
+        # A missing key still yields 0, because _xyt_and_ts() defaults
+        # it -- so the two cases stay distinguishable. Caught in review
+        # by Copilot on PR #590.
+        ts = int(raw_ts)
     except (TypeError, ValueError):
         _LOGGER.debug("rrtp: unparsable coordinates %r", xyt)
         return None

--- a/tests/test_rrtp.py
+++ b/tests/test_rrtp.py
@@ -173,6 +173,54 @@ class TestBothReplyShapes:
 
         assert rrtp.parse_response(reply) is None
 
+    def test_a_missing_ts_defaults_but_an_explicit_null_does_not(self) -> None:
+        """Keep the strictness the parser had before both shapes existed.
+
+        A missing key means "not stated" and has always yielded 0. An
+        explicit `null` or `""` means the robot said something and it
+        was not a timestamp -- that used to raise inside `int()` and
+        reject the whole reply.
+
+        The first version of this change read `int(raw_ts or 0)`, which
+        collapsed all three into 0 and would have produced positions
+        stamped at the epoch. Caught in review on PR #590.
+        """
+        missing = {"ver": "1.0.0", "data": [{"coords": [1.0, 2.0, 3.0]}]}
+        pose = rrtp.parse_response(missing)
+        assert pose is not None
+        assert pose.timestamp == 0
+
+        for bad in (None, ""):
+            reply = {
+                "ver": "1.0.0",
+                "data": [{"coords": [1.0, 2.0, 3.0], "ts": bad}],
+            }
+            assert rrtp.parse_response(reply) is None, bad
+
+    def test_the_object_form_keeps_the_same_ts_rules(self) -> None:
+        """The two shapes must not disagree about what a bad ts means."""
+        missing = {
+            "ver": "1.0.0",
+            "data": [
+                {"coords": [{"type": "current", "xyt": [1.0, 2.0, 3.0]}]}
+            ],
+        }
+        pose = rrtp.parse_response(missing)
+        assert pose is not None
+        assert pose.timestamp == 0
+
+        explicit_null = {
+            "ver": "1.0.0",
+            "data": [
+                {
+                    "coords": [
+                        {"type": "current", "xyt": [1.0, 2.0, 3.0], "ts": None}
+                    ]
+                }
+            ],
+        }
+        assert rrtp.parse_response(explicit_null) is None
+
     def test_a_short_bare_triple_does_not_unpack(self) -> None:
         """Refuse two numbers where three are needed."""
         reply = {"ver": "1.0.0", "data": [{"coords": [1.0, 2.0], "ts": 1}]}

--- a/tests/test_rrtp.py
+++ b/tests/test_rrtp.py
@@ -47,6 +47,139 @@ NO_FIX = {
 }
 
 
+#: THE SECOND REPLY SHAPE, from a real cloud run (@Thonno, i7+ on lewis
+#: 22.52.10). Same `reportType`, same `ver`, same robot as the object
+#: form above -- minutes apart.
+#:
+#: `coords` IS the triple here, `ts` sits on the entry rather than
+#: inside the coordinate, and `pmapv_id` is absent. The robot had just
+#: finished a mission and was in its dock with the base emptying: still
+#: localised, no mission running.
+BARE_TRIPLE = {
+    "reportType": "current",
+    "reqId": "cloud-1",
+    "ver": "1.0.0",
+    "data": [
+        {
+            "pmap_id": "tM_GAKM5SmyBhqotQtQrtw",
+            "coords": [0.02, 0.07, -1.56],
+            "ts": 1788511060,
+        }
+    ],
+}
+
+#: The same robot mid-mission, object form, for contrast.
+MID_MISSION = {
+    "reportType": "current",
+    "reqId": "cloud-1",
+    "ver": "1.0.0",
+    "data": [
+        {
+            "pmap_id": "tM_GAKM5SmyBhqotQtQrtw",
+            "pmapv_id": "260904T074144",
+            "coords": [
+                {
+                    "type": "current",
+                    "xyt": [-3.63, 3.17, 1.74],
+                    "ts": 1788511012,
+                }
+            ],
+        }
+    ],
+}
+
+
+class TestBothReplyShapes:
+    """Both structures a robot uses to answer `current`.
+
+    Found by field run, not by reading: the bare form was being dropped
+    silently. `_first_dict(coords)` wanted a dict, found a float,
+    returned None, and the caller reported "no fix" for a reply carrying
+    a real position.
+
+    It matters more than its rarity suggests. The bare form appears when
+    the robot is localised with no mission running -- which is where a
+    robot sits at the end of a run, and exactly the reading a live map
+    would want in order to record where the cleaning finished.
+    """
+
+    def test_the_bare_triple_is_a_position(self) -> None:
+        """Read a position out of the bare form."""
+        pose = rrtp.parse_response(BARE_TRIPLE)
+
+        assert pose is not None
+        assert (pose.x, pose.y, pose.theta) == (0.02, 0.07, -1.56)
+
+    def test_the_timestamp_comes_from_the_entry(self) -> None:
+        """Read `ts` from the entry, where this shape puts it.
+
+        Reading it from the coordinate would silently produce 0 -- a
+        position stamped at the epoch, which no caller would question.
+        """
+        pose = rrtp.parse_response(BARE_TRIPLE)
+
+        assert pose is not None
+        assert pose.timestamp == 1788511060
+
+    def test_a_missing_pmapv_id_is_none_not_invented(self) -> None:
+        """Leave it None; the bare form omits it.
+
+        Every other field still resolves.
+        """
+        pose = rrtp.parse_response(BARE_TRIPLE)
+
+        assert pose is not None
+        assert pose.pmapv_id is None
+        assert pose.pmap_id == "tM_GAKM5SmyBhqotQtQrtw"
+
+    def test_the_object_form_still_parses(self) -> None:
+        """Keep the shape that already worked.
+
+        The negative control for the change itself: widening the parser
+        must not cost the object form.
+        """
+        pose = rrtp.parse_response(MID_MISSION)
+
+        assert pose is not None
+        assert (pose.x, pose.y, pose.theta) == (-3.63, 3.17, 1.74)
+        assert pose.timestamp == 1788511012
+        assert pose.pmapv_id == "260904T074144"
+
+    def test_a_list_of_strings_is_not_a_position(self) -> None:
+        """Document the outcome; do NOT read this as guarding the check.
+
+        Strings are stopped twice over -- by the type check here and,
+        failing that, by `float("a")` raising inside the conversion
+        below. Replacing the type check with a bare length test leaves
+        this test passing. Kept because the behaviour is worth pinning,
+        and labelled because a test that cannot fail is worse than no
+        test when someone later reads it as coverage.
+        """
+        coords = ["a", "b", "c"]
+        reply = {"ver": "1.0.0", "data": [{"coords": coords, "ts": 1}]}
+
+        assert rrtp.parse_response(reply) is None
+
+    def test_booleans_are_not_coordinates(self) -> None:
+        """Guard the type check -- the only test here that does.
+
+        `True` is an `int` in Python and `float(True)` is `1.0`, so a
+        length test alone would turn three booleans into the position
+        (1.0, 0.0, 1.0) and report it as a fix. Confirmed by reverting
+        the check: this test fails, the string test above does not.
+        """
+        coords = [True, False, True]
+        reply = {"ver": "1.0.0", "data": [{"coords": coords, "ts": 1}]}
+
+        assert rrtp.parse_response(reply) is None
+
+    def test_a_short_bare_triple_does_not_unpack(self) -> None:
+        """Refuse two numbers where three are needed."""
+        reply = {"ver": "1.0.0", "data": [{"coords": [1.0, 2.0], "ts": 1}]}
+
+        assert rrtp.parse_response(reply) is None
+
+
 class TestParsingRealReplies:
     """Real captures, parsed."""
 


### PR DESCRIPTION
## Problem

A robot answers `reqType: "current"` in **two different structures**, and `_parse_v1()` only handles one. The other is dropped silently and reported as "no fix" for a reply that carried a real position.

Both captured from the same robot, an i7+ on lewis 22.52.10, minutes apart, over the cloud path (`v0XX-irbthbu/things/<blid>/mission/rrtp/report/update`). Same `reportType`, same `ver: "1.0.0"`:

```json
// mid-mission -- the documented shape
{"data":[{"pmap_id":"...","pmapv_id":"260904T074144",
          "coords":[{"type":"current","xyt":[-3.63,3.17,1.74],"ts":1788511012}]}]}

// docked, mission just ended -- undocumented
{"data":[{"pmap_id":"...","coords":[0.02,0.07,-1.56],"ts":1788511060}]}
```

In the second, `coords` **is** the triple, `ts` sits on the entry rather than inside the coordinate, and `pmapv_id` is absent.

`_first_dict(coords)` looks for a dict, finds a float, returns `None`, and `_parse_v1()` gives up. Both payloads run through the current parser as:

```
mid-mission -> RobotPosition(x=-3.63, y=3.17, theta=1.74, ...)
docked      -> None
```

### Why the dropped one matters more than its rarity suggests

The bare form appears when the robot is **localised with no mission running** — confirmed by a third capture: after sitting docked and idle for a while, the same robot goes back to the object form with `type: "unknown"` and no coordinates, because `check_robot_localized()` has gone false by then.

So the bare form is the window right at the end of a run. That is exactly the reading a live map wants in order to record where the cleaning finished, and it is the one being thrown away.

## Fix

New `_xyt_and_ts()` pulls the triple and its timestamp out of one `data` entry, whichever shape was used. `_parse_v1()` calls it instead of `_first_dict()`; the length check below it is unchanged, so "no coordinates" and "malformed coordinates" stay one decision in one place.

Two details that are not obvious:

- **The timestamp comes from the entry in the bare form.** Reading it from the coordinate would silently yield `0` — a position stamped at the epoch, which no caller would question.
- **The numbers are type-checked, not length-checked.** `float(True)` is `1.0`, so a length test alone would turn three booleans into the position `(1.0, 0.0, 1.0)` and report it as a fix.

An unrecognised third shape returns `None` rather than being coerced into either.

## Tests

Seven, built on the three real payloads rather than on invented ones.

Reverting each half of the fix fails a specific test: drop the bare-form branch and three fail; read `ts` from the coordinate and one fails; replace the type check with a length check and one fails.

One test is labelled in its own docstring as **unable to fail** — `["a", "b", "c"]` is stopped twice over, by the type check and again by `float("a")` raising in the conversion below. It is kept because the behaviour is worth pinning, and labelled so nobody later reads it as coverage of the type check. The boolean test is the only one that guards that.

## Credit

Found by @Thonno, who ran a cloud-side probe against his own robot across three states and reported the payloads verbatim. The shape difference was in his output; nobody had asked about it, because nobody knew there was a second shape to ask about.