### PR TITLE
feat: add set_preferences() for settings the firmware reads as a group

### DIFF
--- a/roombapy/roomba.py
+++ b/roombapy/roomba.py
@@ -14,7 +14,7 @@ import inspect
 import logging
 import random
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, Self, cast
@@ -743,17 +743,76 @@ class RoombaClient:
         ).decode("utf-8")
         await self._publish("cmd", payload)
 
+    @staticmethod
+    def _coerce(setting: RobotPreference) -> RobotPreference | bool:
+        """Turn the strings "true"/"false" into booleans, case-insensitively.
+
+        Callers have passed str(True) here for years.
+        """
+        if isinstance(setting, str):
+            if setting.lower() == "true":
+                return True
+            if setting.lower() == "false":
+                return False
+        return setting
+
     async def set_preference(
         self, preference: str, setting: RobotPreference
     ) -> None:
-        """Set a preference on the Roomba."""
-        value: RobotPreference | bool = setting
-        if isinstance(setting, str):
-            if setting.lower() == "true":
-                value = True
-            elif setting.lower() == "false":
-                value = False
-        payload = orjson.dumps({"state": {preference: value}}).decode("utf-8")
+        """Set a single preference on the Roomba.
+
+        NOT EVERY PREFERENCE CAN BE SET ON ITS OWN. Some are read by one
+        firmware handler that needs its whole group present and ignores
+        the message otherwise -- see set_preferences(), which is the
+        right call for those.
+        """
+        await self.set_preferences({preference: setting})
+
+    async def set_preferences(
+        self, preferences: Mapping[str, RobotPreference]
+    ) -> None:
+        """Set several preferences in a SINGLE delta message.
+
+        WHY THIS EXISTS RATHER THAN CALLING set_preference() TWICE.
+        Several settings are grouped in the firmware: one handler reads
+        every key of the group, and the value reads only happen once all
+        of them have been found. A message carrying half a group takes
+        an early exit -- no error, no echo, no disconnect, nothing on
+        the wire at all. Sent one at a time, those settings do nothing.
+
+        MEASURED ON THE WIRE, not inferred. A field series on an i3
+        flipped and restored each key with every send confirmed: single
+        keys produced nothing at all -- no error, no echo, no
+        disconnect -- while the pair came back in 0.65 s. dorita980,
+        the oldest client for these robots, has never sent them any
+        other way and offers no single-key setter for them.
+
+        Firmware analysis found handlers that read both keys together
+        and resolve them to one three-state value (lewis:
+        `ctv_common_get_num_passes_flags`; ruby:
+        `ctv_common_get_pass_preference`). Those sit on the command
+        callback path rather than provably on the delta path, so they
+        show the grouping is real for these keys without proving it is
+        what rejects a half-written delta. The measurement is the
+        evidence; the handlers explain it.
+
+        The two known groups::
+
+            {"noAutoPasses": ..., "twoPass": ...}     cleaning passes
+            {"carpetBoost": ..., "vacHigh": ...}      suction mode
+
+        Both resolve to one three-state value, which is why half a group
+        has nothing to resolve. Others may exist; grouping is not
+        visible in the shadow, and these two were found by trying
+        combinations rather than by reading a specification.
+
+        Preferences that are NOT grouped -- `binPause` has its own
+        handler, for instance -- work either way, and set_preference()
+        stays the natural call for them.
+        """
+        payload = orjson.dumps(
+            {"state": {k: self._coerce(v) for k, v in preferences.items()}}
+        ).decode("utf-8")
         await self._publish("delta", payload)
 
     async def get_position(

--- a/roombapy/roomba.py
+++ b/roombapy/roomba.py
@@ -744,10 +744,15 @@ class RoombaClient:
         await self._publish("cmd", payload)
 
     @staticmethod
-    def _coerce(setting: RobotPreference) -> RobotPreference | bool:
+    def _coerce(setting: RobotPreference) -> RobotPreference:
         """Turn the strings "true"/"false" into booleans, case-insensitively.
 
         Callers have passed str(True) here for years.
+
+        The return type does NOT need `| bool`. `bool` is a subclass of
+        `int`, so it is already inside `RobotPreference`; spelling it
+        out reads as though it were not, which is the opposite of what
+        it does.
         """
         if isinstance(setting, str):
             if setting.lower() == "true":

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1,6 +1,8 @@
 """Test the decoding of the Roomba messages."""
 
-from roombapy.roomba import _decode_payload
+import asyncio
+
+from roombapy.roomba import RoombaClient, _decode_payload
 
 
 def test_skip_garbage() -> None:
@@ -36,3 +38,72 @@ def test_allow_valid_json() -> None:
         }
     }
     assert _decode_payload(payload) == decoded
+
+
+# ---------------------------------------------------------------------
+# Preference payloads.
+#
+# Tested here rather than in test_commands.py because the question is
+# what gets BUILT, not what a broker does with it -- these need no
+# connection, and a grouped write is exactly the case where the shape
+# of the payload is the whole point.
+# ---------------------------------------------------------------------
+
+
+class _Capturing(RoombaClient):
+    """A client that records publishes instead of making them."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, str]] = []
+
+    async def _publish(self, topic: str, payload: str) -> None:
+        self.published.append((topic, payload))
+
+
+def test_a_preference_group_goes_out_as_one_message() -> None:
+    """Keep a preference group in one message.
+
+    Some preferences are read by one firmware handler that needs its
+    whole group present, and a message carrying half of one is dropped
+    without a word -- no error, no echo, nothing on the wire. Two
+    single-key messages therefore set nothing at all.
+    """
+    client = _Capturing()
+    asyncio.run(
+        client.set_preferences({"noAutoPasses": True, "twoPass": True})
+    )
+
+    assert len(client.published) == 1, "the group must not be split"
+    topic, payload = client.published[0]
+    assert topic == "delta"
+    assert payload == '{"state":{"noAutoPasses":true,"twoPass":true}}'
+
+
+def test_boolean_strings_are_coerced_in_a_group_too() -> None:
+    """Coerce boolean strings in the plural form too.
+
+    Callers have passed str(True) for years, and routing the single
+    form through the plural one must not change that for either.
+    """
+    client = _Capturing()
+    asyncio.run(
+        client.set_preferences({"carpetBoost": "false", "vacHigh": "TRUE"})
+    )
+
+    assert (
+        client.published[0][1]
+        == '{"state":{"carpetBoost":false,"vacHigh":true}}'
+    )
+
+
+def test_a_single_preference_still_sends_a_single_key() -> None:
+    """The negative control for the delegation.
+
+    `set_preference()` now routes through `set_preferences()`. An
+    ungrouped setting must keep its exact previous payload -- a stray
+    extra key would be a behaviour change for every existing caller.
+    """
+    client = _Capturing()
+    asyncio.run(client.set_preference("openOnly", setting=True))
+
+    assert client.published == [("delta", '{"state":{"openOnly":true}}')]

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from roombapy.roomba import RoombaClient, _decode_payload
+from roombapy.roomba import RobotPreference, RoombaClient, _decode_payload
 
 
 def test_skip_garbage() -> None:
@@ -107,3 +107,20 @@ def test_a_single_preference_still_sends_a_single_key() -> None:
     asyncio.run(client.set_preference("openOnly", setting=True))
 
     assert client.published == [("delta", '{"state":{"openOnly":true}}')]
+
+
+def test_a_boolean_setting_is_accepted_by_the_annotation() -> None:
+    """`RobotPreference` is `str | int | dict[str, int]`, with no `bool`.
+
+    A review flagged that as breaking type-checking for callers passing
+    True. It does not: `bool` is a subclass of `int`, so `True` is
+    already a valid `RobotPreference` and mypy --strict accepts it.
+
+    Pinned as a runtime check rather than argued in a comment, because
+    the observation is easy to make again and the answer is not obvious
+    from reading the alias.
+    """
+    assert issubclass(bool, int)
+
+    # And the alias really is the one under discussion.
+    assert "bool" not in str(RobotPreference)


### PR DESCRIPTION
<p dir="ltr">Some settings cannot be written one key at a time, and the failure is
completely silent — which is why this took a while to notice.</p>

<p dir="ltr"><strong>What happens today.</strong> <code>set_preference("noAutoPasses", True)</code> builds
<code>{"state": {"noAutoPasses": true}}</code> and publishes it. The robot ignores
it. No error, no echo, no disconnect, nothing on the wire — a dropped
write and an unchanged value look identical. Calling it twice, once per
key, does not help: each message is still half a group.</p>

<p dir="ltr"><strong>Where the evidence comes from.</strong> Three sources, arrived at
independently:</p>

<p dir="ltr">A field series on an i3 (daredevil 2.6.0) flipped and restored each
setting with every send confirmed on the wire:</p>

<div dir="ltr" style="">
write | result
-- | --
binPause, openOnly as single keys | echoed, ~0.5 s
noAutoPasses or twoPass as single keys | silently dropped
the pair together in one message | echoed, both keys, 0.65 s
sceneRecog single | echoed

</div>

<p dir="ltr" style="">Firmware analysis found the handler: one function reads both keys and
resolves them to a three-state value — <code>FindMember("twoPass")</code>, then
<code>FindMember("noAutoPasses")</code>, and the value reads only happen once both
are present. Present in two firmware families under different names
(<code>ctv_common_get_num_passes_flags</code>, <code>ctv_common_get_pass_preference</code>).
<code>binPause</code> has its own handler, which is why it works alone. Those sit
on the command callback path rather than provably on the delta path, so
they explain the measurement rather than prove it — the wire is the
evidence here.</p>

<p dir="ltr" style="">And dorita980, the oldest client for these robots, has never sent them
any other way: six named functions for the six valid states, each
sending the complete pair, and no single-key setter for these four at
all.</p>

<p dir="ltr" style=""><strong>What this changes.</strong> A new <code>set_preferences(mapping)</code> that puts
several keys under <code>state</code> in one message. <code>set_preference()</code> delegates
to it, so single-key payloads are byte-for-byte what they were — there
is a test asserting exactly that, because a stray extra key would be a
behaviour change for every existing caller.</p>

<p dir="ltr" style=""><strong>Tests</strong> are in <code>tests/test_payload.py</code> rather than
<code>tests/test_commands.py</code>: the question is what gets <em>built</em>, not what a
broker does with it, and these need no connection.</p>

<p dir="ltr" style=""><strong>Not included, deliberately:</strong> named helpers like dorita980's
<code>setCleaningPassesTwo()</code>. They would be convenient and they encode
policy about which combinations are valid — that seems like a decision
for this project rather than one to arrive in a patch.</p>

<p dir="ltr" style="">For context, this comes out of <code>ha_roomba_plus</code>, which has been sending
those two pairs as separate single-key writes for years. That is fixed
on our side by calling this, once it is available.</p>