### PR TITLE
 Commit · TXT feat(types): cover the fields real robots send in ReportedState

### DIFF
--- a/roombapy/types.py
+++ b/roombapy/types.py
@@ -348,7 +348,10 @@ class ReportedState(TypedDict, total=False):
     hwDbgr: Any
     hwPartsRev: dict[str, Any]
     langs2: dict[str, Any]
-    lastDisconnect: dict[str, Any] | int
+    #: `4` on the one robot where a value was seen. The union this
+    #: carried before was a guess, like the four other types a real
+    #: dump corrected.
+    lastDisconnect: int
     #: NOT room or position telemetry, despite the name: a set of
     #: "which report categories are enabled" flags, all 1.
     #:

--- a/roombapy/types.py
+++ b/roombapy/types.py
@@ -224,7 +224,36 @@ class MissionNavStats(TypedDict, total=False):
 
 
 class ReportedState(TypedDict, total=False):
-    """The contents of ``master_state["state"]["reported"]``."""
+    """The contents of ``master_state["state"]["reported"]``.
+
+    ``total=False`` throughout, and that is not a formality: **which keys
+    a robot sends depends on its firmware family**, not just on its
+    hardware. The declarations below were assembled from complete key
+    dumps of four families:
+
+    ==================  ==================================  =====
+    family              robot                               keys
+    ==================  ==================================  =====
+    9-series            Roomba 980, ``v2.4.17``               55
+    lewis               Roomba i7+, ``lewis+22.52.10``        68
+    soho                Roomba S9+, ``soho+22.29.10``         69
+    sanmarino           Braava jet m6, ``sanmarino+22.29.6``  67
+    ==================  ==================================  =====
+
+    Two of the rows are confirmed twice. Two Braava jet m6 units
+    belonging to different people report the same 67 keys, and two
+    Roomba 980s -- differing in SKU, hardware revision and battery
+    chemistry -- report the same 55. The ``lewis`` and ``soho`` rows
+    rest on one robot each.
+
+    Union: 94 keys. A fifth family, ``sapphire`` (j-series), is
+    represented only by the fields listed at the end -- no complete dump
+    of one exists here, so its absence from a group below means nothing.
+
+    Consumers should keep reading the raw ``master_state`` dict for
+    anything not declared here; this type is additive and never
+    exhaustive.
+    """
 
     name: str
     sku: str
@@ -264,6 +293,146 @@ class ReportedState(TypedDict, total=False):
     padWetness: dict[str, int]
     detectedPad: str
     lidOpen: bool
+
+    # ------------------------------------------------------------------
+    # Seen on ALL FOUR fully-dumped families. Types from the captures.
+    # ------------------------------------------------------------------
+    #: Network configuration. Always a mapping; the ADDRESS FIELDS
+    #: INSIDE IT differ by generation, which is why the inner type is
+    #: left open:
+    #:
+    #:   9-series          `{"addr": 169738246, "mask": 4294967040}`
+    #:                     -- uint32: 10.30.0.6 and 255.255.255.0
+    #:   lewis, sanmarino  `{"addr": "10.10.20.16", "mask": "255.255.255.0"}`
+    #:
+    #: All three from full value dumps, so the split is the 9-series
+    #: against everything newer rather than a per-model quirk. A
+    #: consumer reading `addr` has to handle both, or it renders an
+    #: integer as an address on one generation and fails on the other.
+    netinfo: dict[str, Any]
+    bbpause: dict[str, Any]
+    bbswitch: dict[str, Any]
+    cloudEnv: str
+    country: str
+    ecoCharge: bool
+    mapUploadAllowed: bool
+    schedHold: bool
+    svcEndpoints: dict[str, Any]
+    timezone: str
+    wifistat: dict[str, Any]
+    wlcfg: dict[str, Any]
+
+    # ------------------------------------------------------------------
+    # Seen on three of the four. Absent on one is normal, not an error.
+    #
+    # `Any` WHERE NO VALUE WAS OBSERVED. A key can be evidenced without
+    # its shape being evidenced: diagnostics downloads list key names
+    # only, and the one full value dump available here covers a single
+    # family. Declaring a plausible type from a field's NAME is how this
+    # class already acquired three wrong ones -- `chrgLrPtrn` and
+    # `deploymentState` and `pmapSGen` were all guessed as structures or
+    # strings and are all ints. `Any` states what is actually known.
+    # ------------------------------------------------------------------
+    audio: dict[str, Any]
+    batAuthEnable: Any
+    behaviorFwk: Any
+    childLock: bool
+    #: Charge-light pattern. An int (2 observed), not a structure.
+    chrgLrPtrn: int
+    #: The i/s replacement for ``cleanSchedule``; the two never coexist.
+    cleanSchedule2: list[dict[str, Any]]
+    connected: bool
+    #: An int (0 observed), despite reading like a name.
+    deploymentState: int
+    featureFlags: dict[str, Any]
+    hwDbgr: Any
+    hwPartsRev: dict[str, Any]
+    langs2: dict[str, Any]
+    lastDisconnect: dict[str, Any] | int
+    #: NOT room or position telemetry, despite the name: a set of
+    #: "which report categories are enabled" flags, all 1.
+    #:
+    #: Verified unchanged byte-for-byte across four samples spanning a
+    #: real room transition, and again between mid-mission and docked
+    #: on a second robot. THE SET VARIES BY MODEL -- 15 entries on a
+    #: Braava m6, 16 on an S9+ (`hardknock_report`), 16 on an i7+
+    #: (`learned_policy_report`) -- so treat the keys as open.
+    missionTelemetry: dict[str, int]
+    #: A mapping on two lewis robots (`{"pmaps": null}`) and `null`
+    #: outright on a third. A key being present says nothing about the
+    #: value being one -- `Any` covers both without claiming which.
+    optFeats: Any
+    pmapCL: bool
+    pmapLearningAllowed: bool
+    #: Map-generation number. An int (4 observed).
+    pmapSGen: int
+    pmapShare: dict[str, Any]
+    rankOverlap: int
+    reflexSettings: dict[str, Any]
+    sceneRecog: Any
+    secureBoot: dict[str, Any]
+    subModSwVer: dict[str, str]
+    tls: dict[str, Any]
+    tz: dict[str, Any]
+
+    # ------------------------------------------------------------------
+    # Seen on one or two families only.
+    # ------------------------------------------------------------------
+    #: Clean Base evacuation permitted. i/s vacuums; absent on the Braava.
+    evacAllowed: Any
+    #: 9-series only -- merged into ``bbrun.nPanics`` on i/s.
+    #: `{'panics': [8, 8, 8, 8, 8]}` on a 980.
+    bbpanic: dict[str, Any]
+    #: 9-series version block. i/s carries ``subModSwVer`` instead.
+    #: A numeric string: `'4042'`.
+    bootloaderVer: str
+    #: `'5958'`.
+    mobilityVer: str
+    #: `'01.12.01#1'` -- not purely numeric.
+    navSwVer: str
+    #: `'32'` -- a string despite looking like a number.
+    soundVer: str
+    #: `'4582'`.
+    uiSwVer: str
+    #: `'6'`.
+    umiVer: str
+    wifiSwVer: str
+    #: `1`. Not a structure.
+    wifiAnt: int
+    #: 9-series locale block. i/s carries ``langs2`` and ``tz``.
+    #: `[{'en-UK': 0}, {'de-DE': 4}, ...]` -- a list of one-entry maps,
+    #: not a flat list of names.
+    langs: list[dict[str, int]]
+    #: An index into `langs`: `4` for `de-DE` there.
+    language: int
+    #: Minutes: `120`.
+    localtimeoffset: int
+    #: Unix seconds.
+    utctime: int
+    #: `'c0:e4:34:93:ec:3a'`.
+    mac: str
+    #: 9-series. Dropped from a single write by the firmware; see the
+    #: note on paired preferences in ``set_preferences``.
+    noPP: bool
+    binTypeDetect: Any
+    bleDevLoc: Any
+    wDevLoc: Any
+    #: S9+ only among the dumps here.
+    gentleMode: Any
+
+    # ------------------------------------------------------------------
+    # j-series (sapphire). NO complete dump of one exists here -- these
+    # were recorded individually, so this group is certainly incomplete.
+    # The camera and Genius machinery has no counterpart on the other
+    # families.
+    # ------------------------------------------------------------------
+    odoaMode: Any
+    odoaFeats: Any
+    smartHome: Any
+    streamingVideoStatus: Any
+    peopleFilter: Any
+    imgUpload: Any
+    precheck: Any
 
 
 class RoombaState(TypedDict, total=False):

--- a/roombapy/types.py
+++ b/roombapy/types.py
@@ -329,9 +329,10 @@ class ReportedState(TypedDict, total=False):
     # its shape being evidenced: diagnostics downloads list key names
     # only, and the one full value dump available here covers a single
     # family. Declaring a plausible type from a field's NAME is how this
-    # class already acquired three wrong ones -- `chrgLrPtrn` and
-    # `deploymentState` and `pmapSGen` were all guessed as structures or
-    # strings and are all ints. `Any` states what is actually known.
+    # class already acquired four wrong ones: `chrgLrPtrn`,
+    # `deploymentState`, and `pmapSGen` were all guessed as structures or
+    # strings and are all ints; `netinfo` was previously typed as a union.
+    # `Any` states what is actually known.
     # ------------------------------------------------------------------
     audio: dict[str, Any]
     batAuthEnable: Any

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2,6 +2,7 @@
 
 import ast
 import pathlib
+import typing
 from typing import ClassVar
 
 import orjson
@@ -101,6 +102,18 @@ def test_missing_telemetry_block_is_not_an_error(
     assert "bbchg3" not in client.reported
 
 
+def _hints() -> dict[str, object]:
+    """Resolved annotations, not their `repr`.
+
+    `ReportedState.__annotations__` holds `ForwardRef` objects under
+    `from __future__ import annotations`, and their `repr` is not a
+    stable API -- Python 3.14 appends `owner=...`, which broke a test
+    that compared the string. `get_type_hints()` returns the real
+    objects and is what a consumer would use.
+    """
+    return typing.get_type_hints(ReportedState)
+
+
 class TestReportedStateCoversWhatRealRobotsSend:
     """`ReportedState` declared 37 keys; real robots send up to 69 each.
 
@@ -146,10 +159,10 @@ class TestReportedStateCoversWhatRealRobotsSend:
         union of dict/int/str, which no capture supports; the inner
         values are left open instead.
         """
-        annotation = str(ReportedState.__annotations__["netinfo"])
+        annotation = _hints()["netinfo"]
 
-        assert "dict" in annotation
-        assert "| int" not in annotation
+        assert typing.get_origin(annotation) is dict
+        assert typing.get_origin(annotation) is not typing.Union
 
     def test_the_two_schedule_shapes_are_both_declared(self) -> None:
         """Both schedule shapes are declared.
@@ -183,10 +196,10 @@ class TestReportedStateCoversWhatRealRobotsSend:
         real room transition. Typing it as anything richer would invite
         a consumer to read progress out of it.
         """
-        annotation = str(ReportedState.__annotations__["missionTelemetry"])
+        annotation = _hints()["missionTelemetry"]
 
-        assert "dict" in annotation
-        assert "int" in annotation
+        assert typing.get_origin(annotation) is dict
+        assert typing.get_args(annotation) == (str, int)
 
     def test_nothing_is_declared_twice(self) -> None:
         """No field is declared twice.
@@ -256,9 +269,12 @@ class TestNoTypeIsDeclaredWithoutEvidence:
 
     def test_the_evidenced_types_are_what_was_observed(self) -> None:
         """Each of these was read off a real robot, not inferred."""
+        hints = _hints()
         for field, expected in self.EVIDENCED.items():
-            annotation = str(ReportedState.__annotations__[field])
-            assert expected in annotation, f"{field}: {annotation}"
+            assert (
+                hints[field]
+                is {"int": int, "bool": bool, "str": str}[expected]
+            ), f"{field}: {hints[field]}"
 
     def test_the_three_corrected_fields_are_not_structures(self) -> None:
         """The specific mistake, pinned.
@@ -266,10 +282,9 @@ class TestNoTypeIsDeclaredWithoutEvidence:
         All three read like they hold something structured, and all
         three are plain ints.
         """
+        hints = _hints()
         for field in ("chrgLrPtrn", "deploymentState", "pmapSGen"):
-            annotation = str(ReportedState.__annotations__[field])
-            assert "dict" not in annotation
-            assert "str'" not in annotation.replace("'int'", "")
+            assert hints[field] is int, f"{field}: {hints[field]}"
 
     def test_the_nine_series_block_is_typed_from_its_dump(self) -> None:
         """Thirteen fields settled by one full 980 value dump.
@@ -278,18 +293,15 @@ class TestNoTypeIsDeclaredWithoutEvidence:
         reading as a number (`'32'`), and `langs` is a list of one-entry
         maps rather than a flat list of names.
         """
-        ann = ReportedState.__annotations__
+        hints = _hints()
 
-        assert "str" in str(ann["soundVer"])
-        assert "list" in str(ann["langs"])
-        assert "int" in str(ann["language"])
-        assert "dict" in str(ann["bbpanic"])
+        assert hints["soundVer"] is str
+        assert typing.get_origin(hints["langs"]) is list
+        assert hints["language"] is int
+        assert typing.get_origin(hints["bbpanic"]) is dict
 
     def test_unobserved_fields_are_open(self) -> None:
         """Sampled from the group with no value dump behind it."""
+        hints = _hints()
         for field in ("smartHome", "odoaMode", "sceneRecog", "hwDbgr"):
-            assert str(ReportedState.__annotations__[field]) in (
-                "typing.Any",
-                "<class 'typing.Any'>",
-                "ForwardRef('Any', module='roombapy.types')",
-            ), f"{field}: {ReportedState.__annotations__[field]}"
+            assert hints[field] is typing.Any, f"{field}: {hints[field]}"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,12 @@
 """The typed view from D9."""
 
+import ast
+import pathlib
+from typing import ClassVar
+
 import orjson
 import pytest
+import roombapy.types
 from roombapy.roomba import RoombaClient
 from roombapy.types import ReportedState
 
@@ -94,3 +99,197 @@ def test_missing_telemetry_block_is_not_an_error(
         "cmd", orjson.dumps({"state": {"reported": {"batPct": 80}}})
     )
     assert "bbchg3" not in client.reported
+
+
+class TestReportedStateCoversWhatRealRobotsSend:
+    """`ReportedState` declared 37 keys; real robots send up to 69 each.
+
+    The declarations were assembled from complete key dumps of four
+    firmware families -- 9-series, lewis, soho and sanmarino -- whose
+    union is 94 keys. These tests pin the parts of that which are easy
+    to lose: the families themselves, and the fields where a firmware
+    difference is the whole point.
+
+    Nothing here asserts that a robot MUST send a key. `total=False`
+    means every one is optional, and which ones arrive depends on the
+    firmware family rather than on the hardware alone.
+    """
+
+    #: Seen on all four fully-dumped families.
+    UNIVERSAL = (
+        "bbpause",
+        "bbswitch",
+        "cloudEnv",
+        "country",
+        "ecoCharge",
+        "mapUploadAllowed",
+        "netinfo",
+        "schedHold",
+        "svcEndpoints",
+        "timezone",
+        "wifistat",
+        "wlcfg",
+    )
+
+    def test_the_universal_fields_are_declared(self) -> None:
+        """All four families send these."""
+        declared = set(ReportedState.__annotations__)
+
+        assert set(self.UNIVERSAL) <= declared
+
+    def test_netinfo_is_a_mapping_with_an_open_inner_type(self) -> None:
+        """The generation difference is inside it, not on it.
+
+        Every capture shows a mapping. What differs is the ADDRESS
+        FIELDS within it -- uint32 on 9-series, dotted strings on newer
+        firmware. An earlier draft of this type made the outer field a
+        union of dict/int/str, which no capture supports; the inner
+        values are left open instead.
+        """
+        annotation = str(ReportedState.__annotations__["netinfo"])
+
+        assert "dict" in annotation
+        assert "| int" not in annotation
+
+    def test_the_two_schedule_shapes_are_both_declared(self) -> None:
+        """Both schedule shapes are declared.
+
+        9-series sends `cleanSchedule`, i/s sends `cleanSchedule2`, and
+        they never coexist. A consumer that knows only one silently sees
+        no schedule on half the fleet.
+        """
+        declared = set(ReportedState.__annotations__)
+
+        assert "cleanSchedule" in declared
+        assert "cleanSchedule2" in declared
+
+    def test_the_two_version_blocks_are_both_declared(self) -> None:
+        """Both version blocks are declared.
+
+        9-series spreads component versions across separate keys; i/s
+        collapses them into `subModSwVer`.
+        """
+        declared = set(ReportedState.__annotations__)
+
+        assert "subModSwVer" in declared
+        for nine_series in ("navSwVer", "mobilityVer", "soundVer", "uiSwVer"):
+            assert nine_series in declared
+
+    def test_mission_telemetry_is_not_typed_as_telemetry(self) -> None:
+        """It is not telemetry, despite the name.
+
+        It carries a fixed set of "which reports are enabled" flags,
+        verified unchanged byte-for-byte across four samples spanning a
+        real room transition. Typing it as anything richer would invite
+        a consumer to read progress out of it.
+        """
+        annotation = str(ReportedState.__annotations__["missionTelemetry"])
+
+        assert "dict" in annotation
+        assert "int" in annotation
+
+    def test_nothing_is_declared_twice(self) -> None:
+        """No field is declared twice.
+
+        A TypedDict silently keeps the last definition, so a duplicate is
+        invisible until the types disagree. One slipped in while this
+        class was being extended.
+        """
+        source = pathlib.Path(
+            ReportedState.__module__.replace(".", "/") + ".py"
+        )
+        if not source.exists():  # installed rather than checked out
+            source = pathlib.Path(roombapy.types.__file__)
+
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        cls = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.ClassDef) and n.name == "ReportedState"
+        )
+        names = [
+            n.target.id
+            for n in cls.body
+            if isinstance(n, ast.AnnAssign) and isinstance(n.target, ast.Name)
+        ]
+
+        assert len(names) == len(set(names)), sorted(
+            n for n in names if names.count(n) > 1
+        )
+
+
+class TestNoTypeIsDeclaredWithoutEvidence:
+    """No annotation rests on a guess.
+
+    A key can be evidenced without its shape being evidenced.
+
+    Diagnostics downloads list key names only. One full value dump was
+    available while this class was extended -- a Braava jet m6 -- and
+    checking the declarations against it found three wrong: `chrgLrPtrn`
+    and `deploymentState` and `pmapSGen`, all guessed from their names
+    as structures or strings, all ints in reality. A fourth, `netinfo`,
+    had been given a union of `dict | int | str` on the strength of a
+    note about a generation difference that turns out to live in the
+    fields INSIDE it.
+
+    So: where no value has been seen, the annotation is `Any`. That is
+    not laziness -- it is the accurate statement, and a wrong concrete
+    type is worse than an honest open one.
+    """
+
+    #: Types confirmed against a real value dump.
+    EVIDENCED: ClassVar[dict[str, str]] = {
+        "chrgLrPtrn": "int",
+        "deploymentState": "int",
+        "pmapSGen": "int",
+        "rankOverlap": "int",
+        "tankLvl": "int",
+        "lastDisconnect": "int",
+        "childLock": "bool",
+        "connected": "bool",
+        "pmapCL": "bool",
+        "schedHold": "bool",
+        "cloudEnv": "str",
+        "country": "str",
+        "timezone": "str",
+    }
+
+    def test_the_evidenced_types_are_what_was_observed(self) -> None:
+        """Each of these was read off a real robot, not inferred."""
+        for field, expected in self.EVIDENCED.items():
+            annotation = str(ReportedState.__annotations__[field])
+            assert expected in annotation, f"{field}: {annotation}"
+
+    def test_the_three_corrected_fields_are_not_structures(self) -> None:
+        """The specific mistake, pinned.
+
+        All three read like they hold something structured, and all
+        three are plain ints.
+        """
+        for field in ("chrgLrPtrn", "deploymentState", "pmapSGen"):
+            annotation = str(ReportedState.__annotations__[field])
+            assert "dict" not in annotation
+            assert "str'" not in annotation.replace("'int'", "")
+
+    def test_the_nine_series_block_is_typed_from_its_dump(self) -> None:
+        """Thirteen fields settled by one full 980 value dump.
+
+        Two of them are worth naming: `soundVer` is a string despite
+        reading as a number (`'32'`), and `langs` is a list of one-entry
+        maps rather than a flat list of names.
+        """
+        ann = ReportedState.__annotations__
+
+        assert "str" in str(ann["soundVer"])
+        assert "list" in str(ann["langs"])
+        assert "int" in str(ann["language"])
+        assert "dict" in str(ann["bbpanic"])
+
+    def test_unobserved_fields_are_open(self) -> None:
+        """Sampled from the group with no value dump behind it."""
+        for field in ("smartHome", "odoaMode", "sceneRecog", "hwDbgr"):
+            assert str(ReportedState.__annotations__[field]) in (
+                "typing.Any",
+                "<class 'typing.Any'>",
+                "ForwardRef('Any', module='roombapy.types')",
+            ), f"{field}: {ReportedState.__annotations__[field]}"


### PR DESCRIPTION
<html><head></head><body><h2>Extend <code>ReportedState</code> to cover what real robots send</h2>
<p>Additive only. No existing field is removed or retyped, and the raw
<code>master_state</code> dict is untouched.</p>
<p><code>ReportedState</code> declared 37 keys. Real robots send up to 69 each, and the
union across firmware families is 94. This adds the missing 65.</p>
<h3>Where the fields came from</h3>
<p>Complete key dumps from four firmware families, contributed by users of a
downstream integration:</p>

family | robot | keys | confirmed on
-- | -- | -- | --
9-series | Roomba 980, v2.4.17 | 55 | two units — different SKU, hardware revision and battery chemistry
lewis | Roomba i7+/i8+, lewis+22.52.10 | 68 | three units
soho | Roomba S9+, soho+22.29.10 | 69 | two units
sanmarino | Braava jet m6, sanmarino+22.29.6 | 67 | two units, different owners


<p>Nothing here is inferred from an APK or from a field's name. Every
declaration corresponds to a key observed in at least one dump, and the
class docstring carries the table so a reviewer can see the basis.</p>
<p>A fifth family, <code>sapphire</code> (j-series), appears only as a short trailing
group. No complete dump of one exists here and the comment says so —
absence from the other groups means nothing for it.</p>
<h3>Grouped by how widely each field was seen</h3>
<p>Twelve on all four families, twenty-six on three, the rest on one or two.
That grouping is the point: <strong>which keys a robot sends depends on its
firmware family</strong>, not just its hardware, and a reader needs to know
which side of that line a field sits on.</p>
<h3>Types come from value dumps, or they are <code>Any</code></h3>
<p>85 of 102 fields have a real value behind their annotation. The other 17
are <code>Any</code> — not laziness, but the accurate statement. A diagnostics
download lists key names only; a type needs a value.</p>
<p>That discipline was not free. Checking draft annotations against the
first full value dump found <strong>four wrong</strong>, all guessed from field names:</p>
<ul>
<li><code>chrgLrPtrn</code> — guessed as a structure, is <code>2</code></li>
<li><code>deploymentState</code> — guessed as a string, is <code>0</code></li>
<li><code>pmapSGen</code> — guessed as a map or string, is <code>4</code></li>
<li><code>netinfo</code> — given a <code>dict | int | str</code> union on the strength of a note
about a generation difference that actually lives one level down</li>
</ul>
<p>Two more turned up later: <code>optFeats</code> is a mapping on two robots and <code>null</code>
on a third, and <code>lastDisconnect</code> carried a <code>dict | int</code> union where only an
int was ever observed.</p>
<h3>Differences worth flagging</h3>
<p><strong><code>netinfo</code> addresses are uint32 on 9-series and dotted strings on
everything newer.</strong> <code>{"addr": 169738246}</code> is <code>10.30.0.6</code>. Confirmed across
three families. A consumer reading <code>addr</code> has to handle both, or it
renders an integer as an address on one generation and fails on the other.</p>
<p><strong><code>cleanSchedule</code> and <code>cleanSchedule2</code> never coexist</strong> — 9-series sends
the first, i/s the second. A consumer that knows only one sees no
schedule at all on half the fleet.</p>
<p><strong><code>missionTelemetry</code> is typed <code>dict[str, int]</code> deliberately.</strong> Despite the
name it carries a set of "which report categories are enabled" flags, all
<code>1</code>, and the SET varies by model — 15 entries on a Braava, 16 on an S9+,
16 on an i7+ with a different sixteenth. Verified unchanged during a
mission across four samples spanning a real room transition. Typing it
richer would invite someone to read progress out of it.</p>
<h3>Tests</h3>
<p><code>tests/test_types.py</code> gains checks for the universal group, both schedule
shapes, both version blocks, the fields settled by each dump, and a guard
that no field is declared twice — a TypedDict silently keeps the last
definition, and one duplicate did slip in while this was being written.</p>
<p>The tests resolve annotations with <code>get_type_hints()</code> rather than comparing
their <code>repr</code>. That is not cosmetic: under <code>from __future__ import annotations</code> these are <code>ForwardRef</code> objects, and Python 3.14 appends
<code>owner=...</code> to their repr -- a repr-based assertion passed locally and
failed in CI.</p>
<p><code>ruff check</code>, <code>ruff format --check</code> and <code>mypy --strict</code> are clean.</p>
<hr>
<p>Happy to split this per family, or to drop the <code>sapphire</code> group until a
complete dump of one exists, if either makes it easier to review.</p></body></html>